### PR TITLE
ci: Improve MacOSX build time updating scikit-ci-addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,22 @@ matrix:
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=3.5.2
+        - PYTHON_VERSION=3.5.2
 
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=3.4.5
+        - PYTHON_VERSION=3.4.5
 
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=3.3.6
+        - PYTHON_VERSION=3.3.6
 
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=2.7.12
+        - PYTHON_VERSION=2.7.12
 
 cache:
   directories:
@@ -37,7 +37,7 @@ cache:
     - $HOME/downloads
 
 before_install:
-  - pip install scikit-ci==0.13.0 scikit-ci-addons==0.10.0
+  - pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - ci_addons --install ../addons
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
-  - python -m pip install scikit-ci==0.13.0 scikit-ci-addons==0.10.0
+  - python -m pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - python -m ci_addons --install ../addons
 
   - ps: ../addons/appveyor/rolling-build.ps1

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
   override:
     - curl -fsSL https://git.io/v2Ifs -o ~/bin/circleci-matrix
     - chmod +x ~/bin/circleci-matrix
-    - pip install scikit-ci-addons==0.10.0
+    - pip install scikit-ci-addons==0.11.0
     - ci_addons docker load-pull-save dockcross/manylinux-x64
     - ci_addons docker load-pull-save dockcross/manylinux-x86
 

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -19,7 +19,7 @@ before_install:
   travis:
     osx:
       environment:
-        PATH: $<HOME>/.pyenv/versions/$<PYTHONVERSION>/bin:$<PATH>
+        PATH: $<HOME>/.pyenv/versions/$<PYTHON_VERSION>/bin:$<PATH>
       commands:
         - python ../addons/travis/install_pyenv.py
         - python ../addons/travis/install_cmake.py 3.6.2


### PR DESCRIPTION
$ git shortlog 0.10.0..0.11.0 --no-merges
Jean-Christophe Fillion-Robin (6):
      docs/make_a_release: Re-order steps to account for use of versioneer
      docs/make_a_release: Ensure uploaded distributions are signed
      docs/make_a_release: Update reference to external documentation
      docs/addons: Fix typo in enable-worker-remote-access section
      addon/install_pyenv: Use PYTHON_VERSION instead of PYTHONVERSION
      addon/install_pyenv: Skip brew update/upgrade if python if found in the cache