### PR TITLE
Get the latest setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ cache:
     - $HOME/downloads
 
 before_install:
+  - pip install --upgrade setuptools
   - pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - ci_addons --install ../addons
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
+  - python -m pip install --upgrade setuptools
   - python -m pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - python -m ci_addons --install ../addons
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
   override:
     - curl -fsSL https://git.io/v2Ifs -o ~/bin/circleci-matrix
     - chmod +x ~/bin/circleci-matrix
+    - pip install --upgrade setuptools
     - pip install scikit-ci-addons==0.11.0
     - ci_addons docker load-pull-save dockcross/manylinux-x64
     - ci_addons docker load-pull-save dockcross/manylinux-x86


### PR DESCRIPTION
The current version of setup tools has [a bug](https://github.com/pypa/setuptools/issues/780). This updates on all platforms (needed for Appveyor).