### PR TITLE
Update to cmake 3.8.0 with fixed CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ cache:
     - $HOME/downloads
 
 before_install:
+  - pip install --upgrade setuptools
   - pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - ci_addons --install ../addons
 

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://cmake.org/files/v3.7/cmake-3.7.1.tar.gz")
-set(unix_source_sha256    "449a5bce64dbd4d5b9517ebd1a1248ed197add6ad27934478976fd5f1f9330e1")
+set(unix_source_url       "https://cmake.org/files/v3.8/cmake-3.8.0.tar.gz")
+set(unix_source_sha256    "cab99162e648257343a20f61bcd0b287f5e88e36fcb2f1d77959da60b7f35969")
 
-set(windows_source_url    "https://cmake.org/files/v3.7/cmake-3.7.1.zip")
-set(windows_source_sha256 "17f34341cc63a892679085f2cad3e3d1f172e0518ee7dde43716175033494dfa")
+set(windows_source_url    "https://cmake.org/files/v3.8/cmake-3.8.0.zip")
+set(windows_source_sha256 "b04ea40152633fe351fc60f82b023700dfd84d06b63e3fda87c95b9d01af0cbb")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "17f34341cc63a892679085f2cad3e3d1f172e0518ee7dde437161
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://cmake.org/files/v3.7/cmake-3.7.1-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "7b4b7a1d9f314f45722899c0521c261e4bfab4a6b532609e37fef391da6bade2")
+set(linux64_binary_url    "https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "330357990d84599f9c1a87f568a724f0fe5de1687c32961dda689d52588a5b24")
 
-set(macosx_binary_url    "https://cmake.org/files/v3.7/cmake-3.7.1-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "1851d1448964893fdc5a8c05863326119f397a3790e0c84c40b83499c7960267")
+set(macosx_binary_url    "https://cmake.org/files/v3.8/cmake-3.8.0-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "aba3cf725dfd80324eb4251c13e890c25b65d1b8719454e4769e5d33abd140f1")
 
-set(win32_binary_url    "https://cmake.org/files/v3.7/cmake-3.7.1-win32-x86.zip")
-set(win32_binary_sha256 "d2ec53ba3e3a12f734ed7127704ff9a83361e7cc6f9a0f0b3e2b56d9868a76b9")
+set(win32_binary_url    "https://cmake.org/files/v3.8/cmake-3.8.0-win32-x86.zip")
+set(win32_binary_sha256 "857fca00974ad6ac12fa042373d85ad1288770d4f09fbd99753c822df76b1c6c")
 
-set(win64_binary_url    "https://cmake.org/files/v3.7/cmake-3.7.1-win64-x64.zip")
-set(win64_binary_sha256 "659ecb8207e1266786188c7eaf45308458ba5f719c985970f6f55ec0b5a96746")
+set(win64_binary_url    "https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip")
+set(win64_binary_sha256 "602d6c0bd458291d21414f94ee24f5bb623f3a623409e15601cc80b9922ff6bd")

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.7.1 <https://cmake.org/cmake/help/v3.7/index.html>`_.
+The CMake python wheels provide `CMake 3.8.0 <https://cmake.org/cmake/help/v3.8/index.html>`_.
 
 This project is maintained by Jean-Christophe Fillion-Robin from Kitware Inc.
 It is covered by the `Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
+  - python -m pip install --upgrade setuptools
   - python -m pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
   - python -m ci_addons --install ../addons
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
   override:
     - curl -fsSL https://git.io/v2Ifs -o ~/bin/circleci-matrix
     - chmod +x ~/bin/circleci-matrix
+    - pip install --upgrade setuptools
     - pip install scikit-ci-addons==0.11.0
     - ci_addons docker load-pull-save dockcross/manylinux-x64
     - ci_addons docker load-pull-save dockcross/manylinux-x86

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.7.1 <https://cmake.org/cmake/help/v3.7/index.html>`_.
+The CMake python wheels provide `CMake 3.8.0 <https://cmake.org/cmake/help/v3.8/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -13,7 +13,7 @@ def test_command_line(virtualenv, tmpdir):
 
     virtualenv.run("pip install %s" % wheels[0])
 
-    expected_version = "3.7.1"
+    expected_version = "3.8.0"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
This is a direct PR to master to get the CI to test this. This is intended to fix Appveyor builds.