### PR TITLE
Update to CMake 3.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-log.txt
 # Unit test / coverage reports
 .cache
 .coverage
+.pytest_cache
 .tox
 coverage.xml
 htmlcov

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://cmake.org/files/v3.11/cmake-3.11.0.tar.gz")
-set(unix_source_sha256    "c313bee371d4d255be2b4e96fd59b11d58bc550a7c78c021444ae565709a656b")
+set(unix_source_url       "https://cmake.org/files/v3.11/cmake-3.11.2.tar.gz")
+set(unix_source_sha256    "5ebc22bbcf2b4c7a20c4190d42c084cf38680a85b1a7980a2f1d5b4a52bf5248")
 
-set(windows_source_url    "https://cmake.org/files/v3.11/cmake-3.11.0.zip")
-set(windows_source_sha256 "6b250f1ffc2e27545b715512e6ef3d1d99139763b1721c961f1599906288fc08")
+set(windows_source_url    "https://cmake.org/files/v3.11/cmake-3.11.2.zip")
+set(windows_source_sha256 "dc24bbbebb428ad7e215e5052eca481b68104dcab4c472cbedd6e5d2dbb23d81")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "6b250f1ffc2e27545b715512e6ef3d1d99139763b1721c961f159
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "5babc7953b50715028a05823d18fd91b62805b10aa7811e5fd02b27224d60f10")
+set(linux64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "76b745e84ee24323154163f4ab8419076db0c98b89aec05e426ed2f9347a6f62")
 
-set(macosx_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.0-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "1ea5e27da42817ed80f4bc99bff36acc364420579f6e6d3e59ef5906c67a8286")
+set(macosx_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "1baca0ccec9b412a83a7001cf8dbfd4f80886c42a99d8855816115a6a3a0e672")
 
-set(win32_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.0-win32-x86.zip")
-set(win32_binary_sha256 "c473db9e18c1f27024820df917aa2d9d460f69d4cb0305fbf5da7f96ce99754c")
+set(win32_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-win32-x86.zip")
+set(win32_binary_sha256 "0d8bf9bf56519733a09bd9f39423514adfbb6513ed4e0508a3222e31f1f8264d")
 
-set(win64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.0-win64-x64.zip")
-set(win64_binary_sha256 "e776f4d310b8bc144ab66c3365bfbbd1dcfaad23a13ed0d4929a88a3f4b2bb62")
+set(win64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-win64-x64.zip")
+set(win64_binary_sha256 "8c998fd7c278169e44f19f546de2c9a275e2acc8dbf858f0112a02242dfbbcd2")

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ CMake Python Distributions
     :target: https://travis-ci.org/scikit-build/cmake-python-distributions
 
 `CMake <http://www.cmake.org>`_ is used to control the software compilation
-process using simple platform and compiler independent configuration files, 
+process using simple platform and compiler independent configuration files,
 and generate native makefiles and workspaces that can be used in the
 compiler environment of your choice.
 
@@ -20,7 +20,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.11.0 <https://cmake.org/cmake/help/v3.11/index.html>`_.
+The CMake python wheels provide `CMake 3.11.2 <https://cmake.org/cmake/help/v3.11/index.html>`_.
 
 This project is maintained by Jean-Christophe Fillion-Robin from Kitware Inc.
 It is covered by the `Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.11.0 <https://cmake.org/cmake/help/v3.11/index.html>`_.
+The CMake python wheels provide `CMake 3.11.2 <https://cmake.org/cmake/help/v3.11/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -13,7 +13,7 @@ def test_command_line(virtualenv, tmpdir):
 
     virtualenv.run("pip install %s" % wheels[0])
 
-    expected_version = "3.11.0"
+    expected_version = "3.11.2"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
# Description of the proposed change
This PR updates the package to the latest release of CMake, which is 3.11.2 at the time of writing.

Additionally, the PR appends the `.pytest_cache` directory to `.gitignore`; the directory is created by running `python setup.py test`. If you want, I can drop this commit from this PR, and submit that as a separate PR if you prefer to keep these unrelated changes completely isolated.

## Side note
Unfortunately I didn't discover `scripts/update_cmake_version.py` until after I had manually updated all the relevant files. I did however run the script to verify that my changes are correct.