### PR TITLE
Update to CMake 3.11.4

### DIFF
--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://cmake.org/files/v3.11/cmake-3.11.2.tar.gz")
-set(unix_source_sha256    "5ebc22bbcf2b4c7a20c4190d42c084cf38680a85b1a7980a2f1d5b4a52bf5248")
+set(unix_source_url       "https://cmake.org/files/v3.11/cmake-3.11.4.tar.gz")
+set(unix_source_sha256    "8f864e9f78917de3e1483e256270daabc4a321741592c5b36af028e72bff87f5")
 
-set(windows_source_url    "https://cmake.org/files/v3.11/cmake-3.11.2.zip")
-set(windows_source_sha256 "dc24bbbebb428ad7e215e5052eca481b68104dcab4c472cbedd6e5d2dbb23d81")
+set(windows_source_url    "https://cmake.org/files/v3.11/cmake-3.11.4.zip")
+set(windows_source_sha256 "786899fa415451f6e5b26d092296e2c1aa504dd4a31fef57bed090d80e94fdf3")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "dc24bbbebb428ad7e215e5052eca481b68104dcab4c472cbedd6e
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "76b745e84ee24323154163f4ab8419076db0c98b89aec05e426ed2f9347a6f62")
+set(linux64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "6dab016a6b82082b8bcd0f4d1e53418d6372015dd983d29367b9153f1a376435")
 
-set(macosx_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "1baca0ccec9b412a83a7001cf8dbfd4f80886c42a99d8855816115a6a3a0e672")
+set(macosx_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.4-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "2b5eb705f036b1906a5e0bce996e9cd56d43d73bdee8318ece3e5ce31657b812")
 
-set(win32_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-win32-x86.zip")
-set(win32_binary_sha256 "0d8bf9bf56519733a09bd9f39423514adfbb6513ed4e0508a3222e31f1f8264d")
+set(win32_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.4-win32-x86.zip")
+set(win32_binary_sha256 "b068001ff879f86e704977c50a8c5917e4b4406c66242366dba2674abe316579")
 
-set(win64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.2-win64-x64.zip")
-set(win64_binary_sha256 "8c998fd7c278169e44f19f546de2c9a275e2acc8dbf858f0112a02242dfbbcd2")
+set(win64_binary_url    "https://cmake.org/files/v3.11/cmake-3.11.4-win64-x64.zip")
+set(win64_binary_sha256 "d3102abd0ded446c898252b58857871ee170312d8e7fd5cbff01fbcb1068a6e5")

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.11.2 <https://cmake.org/cmake/help/v3.11/index.html>`_.
+The CMake python wheels provide `CMake 3.11.4 <https://cmake.org/cmake/help/v3.11/index.html>`_.
 
 This project is maintained by Jean-Christophe Fillion-Robin from Kitware Inc.
 It is covered by the `Apache License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.11.2 <https://cmake.org/cmake/help/v3.11/index.html>`_.
+The CMake python wheels provide `CMake 3.11.4 <https://cmake.org/cmake/help/v3.11/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -13,7 +13,7 @@ def test_command_line(virtualenv, tmpdir):
 
     virtualenv.run("pip install %s" % wheels[0])
 
-    expected_version = "3.11.2"
+    expected_version = "3.11.4"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
This PR updates CMake to 3.11.4, which fixes a couple of bugs.
https://blog.kitware.com/cmake-3-11-4-available-for-download/

