### PR TITLE
ci: Automatically upload wheels to PyPi when publishing a tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,96 +1,171 @@
-ci-steps: &ci-steps
-  working_directory: /work
-  steps:
-  - checkout
-  - run:
-      name:
-      command: |
-        export MANYLINUX_PYTHON=$(echo ${CIRCLE_JOB} | cut -d"_" -f2)
-        echo "MANYLINUX_PYTHON [${MANYLINUX_PYTHON}]"
-        /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci
-        /opt/python/${MANYLINUX_PYTHON}/bin/ci
-
 version: 2
+
+references:
+
+  ci_steps: &ci_steps
+    working_directory: /work
+    steps:
+      - checkout
+      - run:
+          name: Run CI
+          command: |
+            #
+            # Set UPLOAD_SDIST environment variable
+            #
+            export UPLOAD_SDIST=$(echo ${CIRCLE_JOB} | cut -d"_" -f3)
+            echo "UPLOAD_SDIST [${UPLOAD_SDIST}]"
+            #
+            # Run CI
+            #
+            export MANYLINUX_PYTHON=$(echo ${CIRCLE_JOB} | cut -d"_" -f2)
+            echo "MANYLINUX_PYTHON [${MANYLINUX_PYTHON}]"
+            /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci
+            /opt/python/${MANYLINUX_PYTHON}/bin/ci
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - dist
+
+  x64_build_job: &x64_build_job
+    docker:
+      - image: dockcross/manylinux-x64
+    <<: *ci_steps
+
+  x86_build_job: &x86_build_job
+    docker:
+      - image: dockcross/manylinux-x86
+    <<: *ci_steps
+
+  no_filters: &no_filters
+    filters:
+      tags:
+        only: /.*/
+
 jobs:
-  #
+
   # x64
-  #
   manylinux-x64_cp27-cp27m:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
-
+    <<: *x64_build_job
   manylinux-x64_cp27-cp27mu:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
-
+    <<: *x64_build_job
   manylinux-x64_cp34-cp34m:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
-
+    <<: *x64_build_job
   manylinux-x64_cp35-cp35m:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
-
+    <<: *x64_build_job
   manylinux-x64_cp36-cp36m:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
+    <<: *x64_build_job
+  manylinux-x64_cp37-cp37m_upload-sdist:
+    <<: *x64_build_job
 
-  manylinux-x64_cp37-cp37m:
-    docker:
-      - image: dockcross/manylinux-x64
-    <<: *ci-steps
-  #
   # x86
-  #
   manylinux-x86_cp27-cp27m:
-    docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
-
+    <<: *x86_build_job
   manylinux-x86_cp27-cp27mu:
-    docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
-
+    <<: *x86_build_job
   manylinux-x86_cp34-cp34m:
-    docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
-
+    <<: *x86_build_job
   manylinux-x86_cp35-cp35m:
-    docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
-
+    <<: *x86_build_job
   manylinux-x86_cp36-cp36m:
-    docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
-
+    <<: *x86_build_job
   manylinux-x86_cp37-cp37m:
+    <<: *x86_build_job
+
+  deploy-master:
     docker:
-      - image: dockcross/manylinux-x86
-    <<: *ci-steps
+      - image: circleci/python:3.7.0-stretch
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Deploy master
+          command: |
+            echo "Deploy master (not implemented)"
+
+  deploy-release:
+    docker:
+      - image: circleci/python:3.7.0-stretch
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Deploy release
+          command: |
+            echo "Deploy release"
+            python -m venv ../venv
+            . ../venv/bin/activate
+            pip install twine
+            ls dist
+            twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*
 
 workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - manylinux-x64_cp27-cp27m
-      - manylinux-x64_cp27-cp27mu
-      - manylinux-x64_cp34-cp34m
-      - manylinux-x64_cp35-cp35m
-      - manylinux-x64_cp36-cp36m
-      - manylinux-x64_cp37-cp37m
+      # x64
+      - manylinux-x64_cp27-cp27m:
+          <<: *no_filters
+      - manylinux-x64_cp27-cp27mu:
+          <<: *no_filters
+      - manylinux-x64_cp34-cp34m:
+          <<: *no_filters
+      - manylinux-x64_cp35-cp35m:
+          <<: *no_filters
+      - manylinux-x64_cp36-cp36m:
+          <<: *no_filters
+      - manylinux-x64_cp37-cp37m_upload-sdist:
+          <<: *no_filters
+      # x86
+      - manylinux-x86_cp27-cp27m:
+          <<: *no_filters
+      - manylinux-x86_cp27-cp27mu:
+          <<: *no_filters
+      - manylinux-x86_cp34-cp34m:
+          <<: *no_filters
+      - manylinux-x86_cp35-cp35m:
+          <<: *no_filters
+      - manylinux-x86_cp36-cp36m:
+          <<: *no_filters
+      - manylinux-x86_cp37-cp37m:
+          <<: *no_filters
 
-      - manylinux-x86_cp27-cp27m
-      - manylinux-x86_cp27-cp27mu
-      - manylinux-x86_cp34-cp34m
-      - manylinux-x86_cp35-cp35m
-      - manylinux-x86_cp36-cp36m
-      - manylinux-x86_cp37-cp37m
+      - deploy-master:
+          requires:
+            # x64
+            - manylinux-x64_cp27-cp27m
+            - manylinux-x64_cp27-cp27mu
+            - manylinux-x64_cp34-cp34m
+            - manylinux-x64_cp35-cp35m
+            - manylinux-x64_cp36-cp36m
+            - manylinux-x64_cp37-cp37m_upload-sdist
+            # x86
+            - manylinux-x86_cp27-cp27m
+            - manylinux-x86_cp27-cp27mu
+            - manylinux-x86_cp34-cp34m
+            - manylinux-x86_cp35-cp35m
+            - manylinux-x86_cp36-cp36m
+            - manylinux-x86_cp37-cp37m
+          filters:
+            branches:
+              only: master
+      - deploy-release:
+          requires:
+            # x64
+            - manylinux-x64_cp27-cp27m
+            - manylinux-x64_cp27-cp27mu
+            - manylinux-x64_cp34-cp34m
+            - manylinux-x64_cp35-cp35m
+            - manylinux-x64_cp36-cp36m
+            - manylinux-x64_cp37-cp37m_upload-sdist
+            # x86
+            - manylinux-x86_cp27-cp27m
+            - manylinux-x86_cp27-cp27mu
+            - manylinux-x86_cp34-cp34m
+            - manylinux-x86_cp35-cp35m
+            - manylinux-x86_cp36-cp36m
+            - manylinux-x86_cp37-cp37m
+          filters:
+            tags:
+              only: /^[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 branches:
  only:
   - master
@@ -44,7 +43,7 @@ cache:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; fi
-  - pip install scikit-ci==0.13.0 scikit-ci-addons==0.11.0
+  - pip install -U scikit-ci scikit-ci-addons
   - ci_addons --install ../addons
 
 install:
@@ -55,6 +54,26 @@ script:
 
 after_success:
   - ci after_test
+
+deploy:
+  # deploy-release
+  - provider: script
+    script: pwd && ls dist;echo "deploy-release" && pip install twine && twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*
+    skip_cleanup: true
+    on:
+      repo: ${TRAVIS_REPO_SLUG}
+      tags: true
+  # deploy-master
+  - provider: script
+    script: pwd && ls dist;echo "deploy-master" && echo "not implemented"
+    skip_cleanup: true
+    on:
+      repo: ${TRAVIS_REPO_SLUG}
+      branch: master
+
 env:
   global:
-    secure: YL5nQR6pOBSC99JH4v7hBX0AE3Qd90b0TaWkReDNVK31eKsasS9FEuamj+BolSu3n3cjcjDa1nWb007KUCC5LoxWQZw4yWyWWaucRewi6xcKnTifidDvchuw/z7B0KNVh3hraetE3kYsPgp/45bwM3889Q/7/HHDfa3iE0q5d3cgKfSbv/MhV5mTuikiogDvJu9v7gvOfnH+tX4QDcR4YMSN57kJfhG0qWrqAmiYuwe95Nzgj/WeWYxo40ULCYISY1lExZOxBtZpjQJeeGW2bnqfHeUYgrSbAnhLc3XIvULHhWHY541PiR7hfkXRCVrJ3Mq0w7b7pn+YIJvofSJan9kCfRT3P+9+3c6mM4lHfln9pTqgn/wpgAgRgYU8ncC2cWwQR56b4anSZXaNjYePAggp+mZdXgwJJ0vHDWYa6RasZgkLlI/ZVi0raPJ7RmTJiP1GDhuaOhg/BkxxzL4fgNOqm73OQuY/EeNCqp6DZWsC638iGw7HmOg4Wb3B5605ZKBWC13hHVpT76dOx7ldkS7O5h056ccyoj5SUSsG3xb0virwMX8yr2MNiaqNF4iHGkECpzZDFmCw/98xZK1yK3xDgSkAs1c63YCxCvSOatHRwW2mWFzVPiPmzG/OfErUQC9fh3k8Vx1khQVNXzAZaabl6v4WAF6sUO8rAPwL9SI=
+    # PYPI_USER
+    - secure: "Xejg5qGnAyo3G+/TaaAr1uHzDv9GLo3mxi6Aw/hZc9gF9lYix1TvkfE6GEBKdPgSLJSqF9NJrwKTt37XH1DjSRLG+qw6Bt1goi5Bkugdk+SC5qmMkvAoG0EKyD119WS4ObrpzqAFcOQqG+4F6iDkSuJLA+dzA3yAzTME4pkhr/2dn0krOSqIcTlgifPwhEaMgo//WRT2dEBM5dWoehXsEMD7VMOUyC0DlV15lKTPKSzTrDEUPU7UFnXgIqZM/brEPbWPQr5Jzgu7BeBk6bmPiiYeh28Cq2juzOzA+JWcGgJmXOfsImYwYuAWZrf0pkE0uQjLySvIBKT7phJv05eNqIxmv/wHK1BPcyMV+2IgFR4+f5ty6C4VUV0hT0HvHr3pMa/8A/5wSNCShEAMTHrwPM5VPWFJtUKTtS5+wwNQDI39MLk/vr9ZTo+y3WJHPaRR0nRpbA3nXFHSqoJJunoMyeI8x9cXZvJ9IENMxGuo3CfBT5RGZamfqSTgn6NjL51ArIMKpvUfm3tXTtlvCHenED1ZQeJI1nWZEalxl8pTyAZoA8S1+h8wraZrUPzhM0QuVpw7vZQeOYu2VSdHO46yxUWoQyb+JWrDTN7EC8vOl7QQzIQlqOWJB5uDJD7UlKKtneTHJrdfXvGxS/hf+Y+hFZK7r+/PDPS6aQjSNDyy+js="
+    # PYPI_PASSWORD
+    - secure: "iEHYaOC/yivDupsbRzohWYCwFMZbCfT2hYOM96akQtOfd1d37rqFCFjDKr3BNyvHyHzj+uNQ7IblynWAqu3cax2Z8b9YuIFXFAslD76IIgeIhxmi8jPtamMK0NBXam/LEL49EIVXUnwVZrWjnLcJxVaBHGS/9Ft3zWP5Gspa4G1yAJDhNfs+jrFipxO4DOBie9mGI2jFdbFRgcCYoY6Jo4y95zxUG1YF5e+8sUobLoBgVqyaJP4SP/Zu/4CEWMfJev8EjLBzzkoPwOU+hC09qwf2FQCvBXFrudpjPpY23WDFeKf+LcMoW9tIoUmP6UJcQibqHeidimrbo9jST0+wTo1NYjrvriKrlMho/QS4iYkd5N6DGUrhSXEMSiqfdMjVGDZ00wvCsT3DwqE9eG7K+Kw09enchjcZcggZIt9crqZPJg3GMdSwPYTlRpf2OQmE4OHL3pN5dSH5Es/sb0X1G6JQgB/2Ia9Aks2ywYEdzUZhbMqfLVx75bVS4bLfYMAMhE/j7NxpYaUlVkFhz3srLhnrYyAcvCQ6XF4cSeFfxD1ie62/qFIF/QH5u76t91uURHygvNdyJCNHhVJnnWgN9kPsJxfyfdOC2Dnrz/jJcw5irsgQVO2/K4iyGyBVoOqwwpymjoCkxB8capEoLRNLcwyQqCTBnMtGykyRYF2I7FA="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,8 +59,10 @@ environment:
       PYTHON_ARCH: "64"
       BLOCK: "0"
 
-  GIRDER_TOKEN:
-    secure: qVsf5rslUEw6KTjGI+uF4hEtP9xkBzZiRmLGsBZN5I32/hNccjih53ydb4tegdnK
+  PYPI_USER:
+    secure: j/nubIi1eucjCtYuwpykWg==
+  PYPI_PASSWORD:
+    secure: qDoPKmtLMdcKUKRHuTlfaajjzO4Q4yu25FM5JuB7z84=
 
 cache:
   - C:\\cmake-3.6.2
@@ -85,6 +87,18 @@ after_test:
 
 on_finish:
   - ps: ../addons/appveyor/enable-worker-remote-access.ps1 -check_for_block
+
+deploy_script:
+  - ps: |
+      if ($env:appveyor_repo_tag -eq $true -and $env:appveyor_repo_tag_name –match "^[0-9]+(\.[0-9]+)*") {
+        Write-Host "deploy release"
+        pip install twine
+        twine upload -u %PYPI_USER% -p %PYPI_PASSWORD% dist/*
+      } elseif ($env:appveyor_repo_branch -eq "master") {
+         Write-Host "deploy master (not implemented)"
+      } else {
+        Write-Host "nothing to deploy"
+      }
 
 matrix:
   fast_finish: false

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -5,7 +5,6 @@ before_install:
   appveyor:
     environment:
       PATH: $<PYTHON_DIR>;$<PYTHON_DIR>\\Scripts;$<PATH>
-      RUN_ENV: .\\..\\addons\\appveyor\\run-with-visual-studio.cmd
     commands:
       - python ../addons/appveyor/patch_vs2008.py
 
@@ -13,15 +12,12 @@ before_install:
     environment:
       PATH: /opt/python/$<MANYLINUX_PYTHON>/bin:$<PATH>
       SETUP_CMAKE_ARGS: -DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl
-    commands:
-      - rm -rf dist/*
 
   travis:
     osx:
       environment:
         PATH: $<HOME>/.pyenv/versions/$<PYTHON_VERSION>/bin:$<PATH>
         SETUP_BDIST_WHEEL_ARGS: --plat-name macosx-10.6-x86_64
-        SETUP_CMAKE_ARGS: -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.6 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 -DCMAKE_OSX_SYSROOT:PATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
       commands:
         - python ../addons/travis/install_pyenv.py
         - python ../addons/travis/install_cmake.py 3.6.2
@@ -31,7 +27,7 @@ install:
     - python -c "import sys; print(sys.version)"
     - python -m pip install --disable-pip-version-check --upgrade pip
     - pip install -U setuptools
-    - $<RUN_ENV> pip install -U -r requirements-dev.txt
+    - pip install -U -r requirements-dev.txt
 
 before_build:
   commands:
@@ -39,8 +35,16 @@ before_build:
 
 build:
   commands:
+    # Source distribution
     - python setup.py --hide-listing sdist
-    - $<RUN_ENV> python setup.py --hide-listing bdist_wheel $<SETUP_BDIST_WHEEL_ARGS> -- $<SETUP_CMAKE_ARGS>
+    - python: |
+              import glob, os
+              if os.environ.get("UPLOAD_SDIST", "") == "":
+                  sdist=(glob.glob("dist/*.tar.gz") + glob.glob("dist/*.zip"))[0]
+                  print("Deleting [%s]" % sdist)
+                  os.remove(sdist)
+    # Built distribution (wheel)
+    - python setup.py --hide-listing bdist_wheel $<SETUP_BDIST_WHEEL_ARGS> -- $<SETUP_CMAKE_ARGS>
 
   circle:
     commands:
@@ -59,15 +63,4 @@ test:
 after_test:
   commands:
     - codecov -X gcov --required --file ./tests/coverage.xml
-    - pip install girder-client==2.0.0
-    - python: |
-              import girder_client, os, subprocess
-              if 'GIRDER_TOKEN' in os.environ:
-                  token = os.environ['GIRDER_TOKEN']
-                  subprocess.check_call(
-                    "python -m girder_client --api-url https://data.kitware.com/api/v1 --api-key {token} \
-                      upload --parent-type collection --reuse 5817c33a8d777f10f26ee3a7 ./dist/".format(token=token),
-                    shell=True)
-              else:
-                  print("Skipping upload: GIRDER_TOKEN environment variable is not set")
     - python setup.py clean


### PR DESCRIPTION
This commit also removes the use of $<RUN_ENV> command wrapper. Indeed,
scikit-build already takes care of setting up the expected environment
and installed requirements are either pure-python packages are already
distributed as wheels.