### PR TITLE
MAINT: remove circular dependency, unused kwarg

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -89,15 +89,6 @@ changed by setting the ``BUILD_VERBOSE`` option::
 
     python setup.py bdist_wheel -- -DBUILD_VERBOSE:BOOL=1
 
-list of files copied into the distributions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-By default, the complete list of files copied into the distributions are
-reported. This can be changed passing the ``--hide-listing`` option::
-
-    python setup.py --hide-listing sdist
-    python setup.py --hide-listing bdist_wheel
-
 Optimizations
 -------------
 

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -11,7 +11,6 @@ before_install:
   circle:
     environment:
       PATH: /opt/python/$<MANYLINUX_PYTHON>/bin:$<PATH>
-      SETUP_CMAKE_ARGS: -DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl
 
   travis:
     osx:
@@ -35,9 +34,9 @@ before_build:
 build:
   commands:
     # Source distribution
-    - python setup.py --hide-listing sdist
+    - python setup.py sdist
     # Built distribution (wheel)
-    - python setup.py --hide-listing bdist_wheel $<SETUP_BDIST_WHEEL_ARGS> -- $<SETUP_CMAKE_ARGS>
+    - python setup.py bdist_wheel $<SETUP_BDIST_WHEEL_ARGS>
     # Cleanup
     - python: |
               import glob, os

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ import sys
 import versioneer
 
 from distutils.text_file import TextFile
-from skbuild import setup
-
+from setuptools import setup
 
 with open('README.rst', 'r') as fp:
     readme = fp.read()
@@ -39,8 +38,6 @@ setup(
     author_email='jchris.fillionr@kitware.com',
 
     packages=['cmake'],
-
-    cmake_install_dir='cmake/data',
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This repo depends on sckikit-build (skbuild) but scikit-build depends on this repo. Break the chain. Maybe need to add setuptools to `requirements.txt`? 

Also `cmake_install_dir` emits a warning on python3.6: `UserWarning: Unknown distribution option: 'cmake_install_dir'`. Do you need it?

Related to scikit-build/scikit-build#420