### PR TITLE
Update to CMake 3.15.5

### DIFF
--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3.tar.gz")
-set(unix_source_sha256    "13958243a01365b05652fa01b21d40fa834f70a9e30efa69c02604e64f58b8f5")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4.tar.gz")
+set(unix_source_sha256    "8a211589ea21374e49b25fc1fc170e2d5c7462b795f1b29c84dd0e984301ed7a")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3.zip")
-set(windows_source_sha256 "0c70e4b50aba829d9283ad77af1ca58d976fcd2811cdb99687be55be427daad9")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4.zip")
+set(windows_source_sha256 "93ae3c35ac4ffecea0a62f6dbe6a6091f0cc5591c3d9f5fc7153746b4b82d371")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "0c70e4b50aba829d9283ad77af1ca58d976fcd2811cdb99687be5
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "020812a9f87293482cec51fdf44f41cc47e794de568f945a8175549d997e1760")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "7c2b17a9be605f523d71b99cc2e5b55b009d82cf9577efb50d4b23056dee1109")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "f5edcf630ef6b1fb6c81ea971e043318b5d4776678701e479841fb58a9c25236")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "adfbf611d21daa83b9bf6d85ab06a455e481b63a38d6e1270d563b03d4e5f829")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-win32-x86.zip")
-set(win32_binary_sha256 "711828fa6744041ea399bbe32e18472a1894594f8b08ce1d96a9cc2d20fcbc18")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-win32-x86.zip")
+set(win32_binary_sha256 "19c2bfd26c4de4d8046dd5ad6de95b57a2556559ec81b13b94e63ea4ae49b3f2")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-win64-x64.zip")
-set(win64_binary_sha256 "a18d96b7839ac3294e5e9f464f0af4c8336a16cd5f95e69a90a259207d7e5177")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-win64-x64.zip")
+set(win64_binary_sha256 "5bb49c0274800c38833e515a01af75a7341db68ea82c71856bb3cf171d2068be")

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4.tar.gz")
-set(unix_source_sha256    "8a211589ea21374e49b25fc1fc170e2d5c7462b795f1b29c84dd0e984301ed7a")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5.tar.gz")
+set(unix_source_sha256    "fbdd7cef15c0ced06bb13024bfda0ecc0dedbcaaaa6b8a5d368c75255243beb4")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4.zip")
-set(windows_source_sha256 "93ae3c35ac4ffecea0a62f6dbe6a6091f0cc5591c3d9f5fc7153746b4b82d371")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5.zip")
+set(windows_source_sha256 "224ee8a2715011a91f404d99501dea31a8baa9ffff5aa88060f6efd12feba967")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "93ae3c35ac4ffecea0a62f6dbe6a6091f0cc5591c3d9f5fc71537
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "7c2b17a9be605f523d71b99cc2e5b55b009d82cf9577efb50d4b23056dee1109")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "03cfd669d0f990040ec89bb63a3ae7f6d61fd17c1c4d5e7ec3d1a35fe1f043f0")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "adfbf611d21daa83b9bf6d85ab06a455e481b63a38d6e1270d563b03d4e5f829")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "b7cc7b3e2b3941eac922b9e788f058e985dfdc361d543d62f641ecc1fe0451b9")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-win32-x86.zip")
-set(win32_binary_sha256 "19c2bfd26c4de4d8046dd5ad6de95b57a2556559ec81b13b94e63ea4ae49b3f2")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win32-x86.zip")
+set(win32_binary_sha256 "54df7fcc47f1ea8b1c7400f9267eea1cac89b4a4dc0a806e9a89decfd97eabbc")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-win64-x64.zip")
-set(win64_binary_sha256 "5bb49c0274800c38833e515a01af75a7341db68ea82c71856bb3cf171d2068be")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-win64-x64.zip")
+set(win64_binary_sha256 "973f83503d5e79eafc10446b3cdaf70d5089eb001d72e995df2b22b66800aeb7")

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.15.3 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.15.4 <https://cmake.org/cmake/help/v3.15/index.html>`_.
 
 Latest Release
 --------------

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.15.4 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.15.5 <https://cmake.org/cmake/help/v3.15/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.15.4 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.15.5 <https://cmake.org/cmake/help/v3.15/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.15.3 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.15.4 <https://cmake.org/cmake/help/v3.15/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.15.3"
+    expected_version = "3.15.4"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.15.4"
+    expected_version = "3.15.5"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
Could we replace the `${release}` syntax with `$release` in the update docs? Converting the set line to fish is expected, but fish not supporting `${x}` makes this much harder to copy and paste after that. `$x` should be supported in most shells.