### PR TITLE
Update to CMake 3.16.0

### DIFF
--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3.tar.gz")
-set(unix_source_sha256    "13958243a01365b05652fa01b21d40fa834f70a9e30efa69c02604e64f58b8f5")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0.tar.gz")
+set(unix_source_sha256    "6da56556c63cab6e9a3e1656e8763ed4a841ac9859fefb63cbe79472e67e8c5f")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3.zip")
-set(windows_source_sha256 "0c70e4b50aba829d9283ad77af1ca58d976fcd2811cdb99687be55be427daad9")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0.zip")
+set(windows_source_sha256 "64ae0f6c4e7563cddaa278501cb5019f994d73fc6f1432eb57456beafa093fc5")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "0c70e4b50aba829d9283ad77af1ca58d976fcd2811cdb99687be5
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "020812a9f87293482cec51fdf44f41cc47e794de568f945a8175549d997e1760")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "85f55f13c922c853049edcf37c828b02b9b2fc00729d0cbb56cf20181a39340b")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "f5edcf630ef6b1fb6c81ea971e043318b5d4776678701e479841fb58a9c25236")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "aa5221fb0be10088a47314546b7be5767056cb10fc2cbf64d18a374f25b226ce")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-win32-x86.zip")
-set(win32_binary_sha256 "711828fa6744041ea399bbe32e18472a1894594f8b08ce1d96a9cc2d20fcbc18")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-win32-x86.zip")
+set(win32_binary_sha256 "710e96a01a133bc8a077fb68ce4b4b960f61d9ec269fb4d2e0c7ce2950303643")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-win64-x64.zip")
-set(win64_binary_sha256 "a18d96b7839ac3294e5e9f464f0af4c8336a16cd5f95e69a90a259207d7e5177")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-win64-x64.zip")
+set(win64_binary_sha256 "2311572c96c3902cff0c42f807c08d07abd44dc981b80bbafa916e1c1be5072b")

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.15.3 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.16.0 <https://cmake.org/cmake/help/v3.16/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.15.3 <https://cmake.org/cmake/help/v3.15/index.html>`_.
+The CMake python wheels provide `CMake 3.16.0 <https://cmake.org/cmake/help/v3.16/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.15.3"
+    expected_version = "3.16.0"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
Note that Python supports macOS 10.9+, but CMake 3.16 currently only supports 10.12+. See https://gitlab.kitware.com/cmake/cmake/issues/20054 .