### PR TITLE
feat: download scikit-build when building from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build",
-    "setuptools",
+    "setuptools>=42",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ requires = [
     "setuptools",
     "wheel"
 ]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This will cause installing from source to succeed or provide a much better error with pip 10+.

See https://github.com/scikit-build/ninja-python-distributions/pull/26 