### PR TITLE
ci: do arm64 builds natively on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,22 @@ matrix:
       env:
         - PYTHON_VERSION=2.7.15
 
+    - os: linux
+      arch: arm64
+      virt: vm
+      group: edge
+      dist: focal
+      language: generic
+      env:
+        - PYTHON_VERSION=3.8.5
+
 before_cache:
   # Cleanup to avoid the cache to grow indefinitely as new package versions are released
   # see https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
-  - brew cleanup
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew cleanup
+    fi
 
 cache:
   directories:
@@ -43,20 +55,40 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" && "${PYTHON_VERSION}" == "3.7.8" ]]; then
       brew install gettext
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; ln -s $(which python2) $HOME/bin/python; fi
-  - python scripts/ssl-check.py
-  - python -m pip install --disable-pip-version-check --upgrade pip
-  - pip install -U scikit-ci scikit-ci-addons
-  - ci_addons --install ../addons
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        mkdir $HOME/bin; ln -s $(which pip2) $HOME/bin/pip; ln -s $(which python2) $HOME/bin/python
+        python scripts/ssl-check.py
+        python -m pip install --disable-pip-version-check --upgrade pip
+        pip install -U scikit-ci scikit-ci-addons
+        ci_addons --install ../addons
+    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        docker run -t --rm \
+            -v $(pwd):/io \
+            --env TRAVIS=True \
+            --env TRAVIS_OS_NAME="${TRAVIS_OS_NAME}" \
+            quay.io/pypa/manylinux2014_aarch64 \
+            /io/scripts/manylinux2014-aarch64-build-and-test-wheel.sh
+    fi
 
 install:
-  - ci install
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        ci install
+    fi
 
 script:
-  - ci test
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        ci test
+    fi
 
 after_success:
-  - ci after_test
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        ci after_test
+    fi
+    pwd && ls dist
 
 deploy:
   # deploy-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ if(CMakePythonDistributions_SUPERBUILD)
         # cache file.
         file(WRITE "${CMAKE_BINARY_DIR}/initial-cache.txt"
 "set(CMAKE_C_FLAGS \"-D_POSIX_C_SOURCE=199506L -D_POSIX_SOURCE=1 -D_SVID_SOURCE=1 -D_BSD_SOURCE=1\" CACHE STRING \"Initial cache\" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS \"-static-libstdc++ -static-libgcc -lrt\" CACHE STRING \"Initial cache\" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\" FORCE)
 ")
         set(_common_args
           CMAKE_ARGS -C "${CMAKE_BINARY_DIR}/initial-cache.txt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PYTHON_DIR: "C:\\Python37"
       PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
+      PYTHON_ARCH: "32"
       BLOCK: "0"
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -38,22 +38,22 @@ environment:
     secure: qDoPKmtLMdcKUKRHuTlfaajjzO4Q4yu25FM5JuB7z84=
 
 init:
-  - python -m pip install -U scikit-ci scikit-ci-addons
-  - python -m ci_addons --install ../addons
+  - "%PYTHON_DIR%\\python.exe -m pip install -U scikit-ci scikit-ci-addons"
+  - "%PYTHON_DIR%\\python.exe -m ci_addons --install ../addons"
 
   - ps: ../addons/appveyor/rolling-build.ps1
 
 install:
-  - python -m ci install
+  - "%PYTHON_DIR%\\python.exe -m ci install"
 
 build_script:
-  - python -m ci build
+  - "%PYTHON_DIR%\\python.exe -m ci build"
 
 test_script:
-  - python -m ci test
+  - "%PYTHON_DIR%\\python.exe -m ci test"
 
 after_test:
-  - python -m ci after_test
+  - "%PYTHON_DIR%\\python.exe -m ci after_test"
 
 on_finish:
   - ps: ../addons/appveyor/enable-worker-remote-access.ps1 -check_for_block

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -56,6 +56,21 @@ before_install:
         - python ../addons/travis/install_pyenv.py
         - python scripts/ssl-check.py
         - python ../addons/travis/install_cmake.py 3.12.0
+    linux:
+      commands:
+        - python: |
+                  import os
+                  import ci
+                  import platform
+                  os.environ["SETUP_BDIST_WHEEL_ARGS"] = "--plat-name %s" % os.environ["AUDITWHEEL_PLAT"]
+                  setup_cmake_args = []
+                  setup_cmake_args.append("-DSTRIP_EXECUTABLE:FILEPATH=/opt/rh/devtoolset-9/root/usr/" + "/bin/strip")
+                  if platform.machine() == "aarch64":
+                      # Remove this after addressing https://github.com/dockcross/dockcross/issues/431
+                      setup_cmake_args.append("-DOPENSSL_ROOT_DIR:PATH=/tmp/openssl-install")
+                  os.environ["SETUP_CMAKE_ARGS"] = " ".join(setup_cmake_args)
+                  os.environ["SETUP_MAKE_ARGS"] = "-j$(nproc)"
+                  ci.driver.Driver.save_env(os.environ)
 
 install:
   commands:
@@ -74,7 +89,7 @@ build:
     # Source distribution
     - python setup.py --hide-listing sdist
     # Built distribution (wheel)
-    - python setup.py --hide-listing bdist_wheel $<SETUP_BDIST_WHEEL_ARGS> -- $<SETUP_CMAKE_ARGS>
+    - python setup.py --hide-listing bdist_wheel $<SETUP_BDIST_WHEEL_ARGS> -- $<SETUP_CMAKE_ARGS> -- $<SETUP_MAKE_ARGS>
     # Cleanup
     - python: |
               import glob, os
@@ -82,6 +97,15 @@ build:
                   sdist=(glob.glob("dist/*.tar.gz") + glob.glob("dist/*.zip"))[0]
                   print("Deleting [%s]" % sdist)
                   os.remove(sdist)
+  travis:
+    linux:
+      commands:
+        - |
+          # Since there are no external shared libraries to bundle into the wheels
+          # this step will fixup the wheel switching from 'linux' to 'manylinux' tag
+          for whl in dist/*linux*_$(arch).whl; do
+              auditwheel repair --plat ${AUDITWHEEL_PLAT} $whl -w ./dist
+          done
 
   circle:
     commands:

--- a/scripts/manylinux2014-aarch64-build-and-install-openssl.sh
+++ b/scripts/manylinux2014-aarch64-build-and-install-openssl.sh
@@ -10,10 +10,10 @@ set -o pipefail
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/utils.sh
 
-OPENSSL_ROOT=openssl-1.1.1g
+OPENSSL_ROOT=openssl-1.1.1h
 
-# Hash from https://www.openssl.org/source/openssl-1.1.1g.tar.gz.sha256
-OPENSSL_HASH=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
+# Hash from https://www.openssl.org/source/openssl-1.1.1h.tar.gz.sha256
+OPENSSL_HASH=5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
 
 # Environment variables defined in "dockcross/manylinux2014-aarch64/Dockerfile.in"
 check_var CROSS_ROOT
@@ -40,7 +40,7 @@ cd ${OPENSSL_ROOT}
   shared
 
 # Build
-make -j$(grep -c processor /proc/cpuinfo)
+make -j$(nproc)
 
 # Install
 make install

--- a/scripts/manylinux2014-aarch64-build-and-test-wheel.sh
+++ b/scripts/manylinux2014-aarch64-build-and-test-wheel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+set -x
+
+MANYLINUX_PYTHON=cp38-cp38
+export PATH="/opt/python/${MANYLINUX_PYTHON}/bin:$PATH"
+
+yum install -y wget
+
+cd /io
+./scripts/manylinux2014-aarch64-build-and-install-openssl.sh
+
+ci_before_install() {
+    /opt/python/${MANYLINUX_PYTHON}/bin/python scripts/ssl-check.py
+    /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci scikit-ci-addons scikit-build
+}
+
+ci_install() {
+    /opt/python/${MANYLINUX_PYTHON}/bin/ci install
+}
+ci_test() {
+    /opt/python/${MANYLINUX_PYTHON}/bin/ci test
+}
+ci_after_success() {
+    /opt/python/${MANYLINUX_PYTHON}/bin/ci after_test
+}
+
+ci_before_install
+ci_install
+ci_test
+ci_after_success


### PR DESCRIPTION
Fixes #115 

Build arm64 wheel on Travis CI in order to build natively, instead of cross compiling from x86_64. This fixes several problems with the Arm wheel. It makes use of `arch: arm64-graviton2`, which is currently only available on travis-ci.com. It is probably possible to build the project on travis-ci.org with `arch: arm64` instead, but it will be significantly slower.

See #115 for more information.