### PR TITLE
Update to CMake 3.18.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,6 @@ references:
       - image: dockcross/manylinux1-x86
     <<: *ci_steps
 
-  aarch64_build_job: &aarch64_build_job
-    docker:
-      - image: dockcross/manylinux2014-aarch64
-    <<: *ci_steps
-
   no_filters: &no_filters
     filters:
       tags:
@@ -59,10 +54,6 @@ jobs:
     <<: *x86_build_job
   manylinux-x86_cp37-cp37m:
     <<: *x86_build_job
-
-  # aarch64
-  manylinux-aarch64_cp37-cp37m:
-    <<: *aarch64_build_job
 
   deploy-master:
     docker:
@@ -105,9 +96,6 @@ workflows:
           <<: *no_filters
       - manylinux-x86_cp37-cp37m:
           <<: *no_filters
-      # aarch64
-      - manylinux-aarch64_cp37-cp37m:
-          <<: *no_filters
 
       - deploy-master:
           requires:
@@ -117,8 +105,6 @@ workflows:
             # x86
             - manylinux-x86_cp27-cp27mu
             - manylinux-x86_cp37-cp37m
-            # aarch64
-            - manylinux-aarch64_cp37-cp37m
           filters:
             branches:
               only: master
@@ -130,8 +116,6 @@ workflows:
             # x86
             - manylinux-x86_cp27-cp27mu
             - manylinux-x86_cp37-cp37m
-            # aarch64
-            - manylinux-aarch64_cp37-cp37m
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - PYTHON_VERSION=2.7.15
 
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       virt: vm
       group: edge
       dist: focal

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz")
-set(unix_source_sha256    "5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4.tar.gz")
+set(unix_source_sha256    "597c61358e6a92ecbfad42a9b5321ddd801fc7e7eca08441307c9138382d4f77")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.zip")
-set(windows_source_sha256 "ccffbd2e983a604ac1b95433e751da8c11e552bbc1e138a953f23fd3e6c594d1")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4.zip")
+set(windows_source_sha256 "16df4f582cce7785d9c9f760d0cd8d1480d158a8b32e80f4570732c5eb205a4c")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "ccffbd2e983a604ac1b95433e751da8c11e552bbc1e138a953f23
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "7b73ef901eb9fe615977a4f2254521cf9ee9da7efcd20c621a61ead51a870948")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "149e0cee002e59e0bb84543cf3cb099f108c08390392605e944daeb6594cbc29")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "7cf5525169b723e6b7544a44c391c36d855df3b51355d60e3aed53d640b8569c")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "9d27049660474cf134ab46fa0e0db771b263313fcb8ba82ee8b2d1a1a62f8f20")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win32-x86.zip")
-set(win32_binary_sha256 "209c7e3cf0eb7e83801858397e48322479eaacbf296b8c02d4d7d4614b1ce5e3")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-win32-x86.zip")
+set(win32_binary_sha256 "4c519051853686927f87df99669ada3ff15a3086535a7131892febd7c6e2f122")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win64-x64.zip")
-set(win64_binary_sha256 "5f4ec834fbd9b62fbf73bc48ed459fa2ea6a86c403106c90fedc2ac76d51612d")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-win64-x64.zip")
+set(win64_binary_sha256 "a932bc0c8ee79f1003204466c525b38a840424d4ae29f9e5fb88959116f2407d")

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.18.2 <https://cmake.org/cmake/help/v3.18/index.html>`_.
+The CMake python wheels provide `CMake 3.18.4 <https://cmake.org/cmake/help/v3.18/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.18.2 <https://cmake.org/cmake/help/v3.18/index.html>`_.
+The CMake python wheels provide `CMake 3.18.4 <https://cmake.org/cmake/help/v3.18/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.18.2"
+    expected_version = "3.18.4"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
- Update to CMake 3.18.4
- Remove redundant (and broken) aarch64 builds from CircleCI
- Switch to using Travis-CI Graviton 2 builder instances which are much faster

I'm creating this PR selfishly in order to bump the cmake version so new wheels can be released to Pypi.org. This will fix the currently broken aarch64 wheel that is published there.