### PR TITLE
added pyproject.toml for build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    'setuptools',
+    'scikit-build',
+]


### PR DESCRIPTION
fixes #103, I encountered this issue while trying to install `line_profiler` using poetry - https://github.com/python-poetry/poetry/issues/3323