### PR TITLE
Add pyproject.toml to specify build requirements for CMake wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "scikit-build",
+    "setuptools",
+    "wheel"
+]


### PR DESCRIPTION
See #103

Co-authored-by: Yoav Alon <yoav@orca.security>