### PR TITLE
ci/travis: Attempt to fix pypi upload of arm64 wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
       group: edge
       dist: focal
       language: generic
-      env:
-        - PYTHON_VERSION=3.8.5
 
 before_cache:
   # Cleanup to avoid the cache to grow indefinitely as new package versions are released
@@ -75,6 +73,8 @@ install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         ci install
+    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        pip install twine
     fi
 
 script:
@@ -88,12 +88,12 @@ after_success:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         ci after_test
     fi
-    pwd && ls dist
+    pwd && ls dist; PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH && twine --version
 
 deploy:
   # deploy-release
   - provider: script
-    script: pwd && ls dist;echo "deploy-release" && ~/.pyenv/versions/${PYTHON_VERSION}/bin/twine upload -u $PYPI_USER -p $PYPI_PASSWORD --skip-existing dist/*
+    script: pwd && ls dist;echo "deploy-release" && PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH && twine upload -u $PYPI_USER -p $PYPI_PASSWORD --skip-existing dist/*
     skip_cleanup: true
     on:
       repo: ${TRAVIS_REPO_SLUG}


### PR DESCRIPTION
<s>**Note:** Merge only after reverting `branch` associated with `deploy-master` from `fix-travis-arm64-release-deployment-step` to `master`</s>

---------------

* Remove setting of PYTHON_VERSION environment variable. This variable
  had non effect and was set to an incorrect value. At the time of this
  commit python version 3.8.2 was the default.

* Explicitly install twine when operating system is Linux

* Update deploy-release step to update PATH instead of explicitly referencing
  the path to twine executable, this will allow the deployment to work on
  both  macOS and Linux

* Update deploy-master step to display version of twine and catch potential
  issue with deploy-release step.