### PR TITLE
chore: update to cmake 3.19.1

### DIFF
--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4.tar.gz")
-set(unix_source_sha256    "597c61358e6a92ecbfad42a9b5321ddd801fc7e7eca08441307c9138382d4f77")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.tar.gz")
+set(unix_source_sha256    "fdda688155aa7e72b7c63ef6f559fca4b6c07382ea6dca0beb5f45aececaf493")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4.zip")
-set(windows_source_sha256 "16df4f582cce7785d9c9f760d0cd8d1480d158a8b32e80f4570732c5eb205a4c")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.zip")
+set(windows_source_sha256 "dcfb5707f92a0b69b3e1702d797142c34126dbb91cc40b4508ae7339ae19e9f7")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "16df4f582cce7785d9c9f760d0cd8d1480d158a8b32e80f457073
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "149e0cee002e59e0bb84543cf3cb099f108c08390392605e944daeb6594cbc29")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "5446cdee900e906e46162a5a7be9b4542bb5e886041cf8cffeda62aae2696ccf")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "9d27049660474cf134ab46fa0e0db771b263313fcb8ba82ee8b2d1a1a62f8f20")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "315eb5500753f797075b6ea43189420e97b0b9f32c8fc87ec94ba1d80b72eb7f")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-win32-x86.zip")
-set(win32_binary_sha256 "4c519051853686927f87df99669ada3ff15a3086535a7131892febd7c6e2f122")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-win32-x86.zip")
+set(win32_binary_sha256 "602111e10c29161417c9833be80a53a5a1013dd9094acea4601776b82365f872")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-win64-x64.zip")
-set(win64_binary_sha256 "a932bc0c8ee79f1003204466c525b38a840424d4ae29f9e5fb88959116f2407d")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-win64-x64.zip")
+set(win64_binary_sha256 "67bbda67c98c5f0789199fe1db650f12274a6ad40fd8cae88d208029ac618905")

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.tar.gz")
-set(unix_source_sha256    "fdda688155aa7e72b7c63ef6f559fca4b6c07382ea6dca0beb5f45aececaf493")
+set(unix_source_url       "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1.tar.gz")
+set(unix_source_sha256    "1d266ea3a76ef650cdcf16c782a317cb4a7aa461617ee941e389cb48738a3aba")
 
-set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.zip")
-set(windows_source_sha256 "dcfb5707f92a0b69b3e1702d797142c34126dbb91cc40b4508ae7339ae19e9f7")
+set(windows_source_url    "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1.zip")
+set(windows_source_sha256 "d3c8fc07b3207c6826b49e46b8194fcdbaab95eaba75dd735e348230efd4400d")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256 "dcfb5707f92a0b69b3e1702d797142c34126dbb91cc40b4508ae7
 set(linux32_binary_url    "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256 "NA")
 
-set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Linux-x86_64.tar.gz")
-set(linux64_binary_sha256 "5446cdee900e906e46162a5a7be9b4542bb5e886041cf8cffeda62aae2696ccf")
+set(linux64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Linux-x86_64.tar.gz")
+set(linux64_binary_sha256 "587fb2d882214511f4b260329800de7903eba7827498f06a0dee234ed579bdc3")
 
-set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-Darwin-x86_64.tar.gz")
-set(macosx_binary_sha256 "315eb5500753f797075b6ea43189420e97b0b9f32c8fc87ec94ba1d80b72eb7f")
+set(macosx_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-Darwin-x86_64.tar.gz")
+set(macosx_binary_sha256 "8b1caf1da7bc738a27c820ca8dc2ddb610b7526b4507095de87d79cd5a27028b")
 
-set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-win32-x86.zip")
-set(win32_binary_sha256 "602111e10c29161417c9833be80a53a5a1013dd9094acea4601776b82365f872")
+set(win32_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win32-x86.zip")
+set(win32_binary_sha256 "7c01b9cc29a0e5051c11c605b7dd43d187fb25b277e7a3dc4085b9eaf36a0387")
 
-set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0-win64-x64.zip")
-set(win64_binary_sha256 "67bbda67c98c5f0789199fe1db650f12274a6ad40fd8cae88d208029ac618905")
+set(win64_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.19.1/cmake-3.19.1-win64-x64.zip")
+set(win64_binary_sha256 "e95d70549f306adb46e0f131dcecdbcbc6412d3a1e073c2c0078812391bf21d3")

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.18.4 <https://cmake.org/cmake/help/v3.18/index.html>`_.
+The CMake python wheels provide `CMake 3.19.0 <https://cmake.org/cmake/help/v3.19/index.html>`_.
 
 Latest Release
 --------------

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.19.0 <https://cmake.org/cmake/help/v3.19/index.html>`_.
+The CMake python wheels provide `CMake 3.19.1 <https://cmake.org/cmake/help/v3.19/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.18.4 <https://cmake.org/cmake/help/v3.18/index.html>`_.
+The CMake python wheels provide `CMake 3.19.0 <https://cmake.org/cmake/help/v3.19/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.19.0 <https://cmake.org/cmake/help/v3.19/index.html>`_.
+The CMake python wheels provide `CMake 3.19.1 <https://cmake.org/cmake/help/v3.19/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/update_cmake_version.rst
+++ b/docs/update_cmake_version.rst
@@ -17,13 +17,13 @@ Available CMake archives can be found at https://cmake.org/files.
 2. Execute `scripts/update_cmake_version.py` command line tool with the desired
    ``X.Y.Z`` CMake version available for download. For example::
 
-    $ release=3.14.4
+    $ release=3.19.0
     $ python scripts/update_cmake_version.py $release
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.14.4'
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.19.0'
     [...]
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.14.4' - done
-    Updating 'CMakeUrls.cmake' with CMake version 3.14.4
-    Updating 'CMakeUrls.cmake' with CMake version 3.14.4 - done
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.19.0' - done
+    Updating 'CMakeUrls.cmake' with CMake version 3.19.0
+    Updating 'CMakeUrls.cmake' with CMake version 3.19.0 - done
     Updating docs/index.rst
     Updating docs/index.rst - done
     Updating README.rst
@@ -34,7 +34,7 @@ Available CMake archives can be found at https://cmake.org/files.
 3. Create a topic named `update-to-cmake-X.Y.Z` and commit the changes.
    For example::
 
-    release=3.14.4
+    release=3.19.0
     git checkout -b update-to-cmake-$release
     git add CMakeUrls.cmake docs/index.rst README.rst tests/test_distribution.py
     git commit -m "Update to CMake $release"

--- a/scripts/update_cmake_version.py
+++ b/scripts/update_cmake_version.py
@@ -62,7 +62,7 @@ def get_cmake_archive_urls_and_sha256s(version, verbose=False):
                         sha256 = line.split()[0].strip()
                         identifier = expected_files[file]
                         shas[identifier] = sha256
-        assert len(shas) == len(expected_files)
+        assert len(shas) == len(expected_files), "{} != {}".format(len(shas), len(expected_files))
 
         # Get download URLs for each asset
         urls = {}

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.18.4"
+    expected_version = "3.19.0"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.19.0"
+    expected_version = "3.19.1"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
#114 has been updated and would be nice to include in 3.19.1's release, too. #117 looks safe to me, too.