### PR TITLE
fix: pin cryptography to a version working on manylinux1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,8 @@ twine
 virtualenv>=15.0.3
 wheel
 wheeltools
+
+# need to pin cryptography for manylinux1 builds
+# cryptography only provides manylinux2010 wheels since 3.4.0
+# because of the lack of a decent rust compiler on manylinux1
+cryptography~=3.3.2 ; sys_platform=="linux" and platform_machine in "i386, i486, i586, i686, x86_64"


### PR DESCRIPTION
cryptography>=3.4 is only usable on manylinux2010+ systems becaus of the lack of a decent rust compiler on older systems.

Pin version of cryptography to 3.3.x on linux i686/x86_64.

Pre-requisite to #127 