### PR TITLE
fix: building from sdist fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
+import os
 import sys
-import versioneer
 
 from distutils.text_file import TextFile
 from skbuild import setup
+
+# Add current folder to path
+# This is required to import versioneer in an isolated pip build
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+import versioneer  # noqa: E402
 
 
 with open('README.rst', 'r') as fp:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import textwrap
 
-from path import Path
+from path import Path, matchers
 
 DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
@@ -24,6 +24,21 @@ def _check_cmake_install(virtualenv, tmpdir):
     output = virtualenv.run("cmake -P %s" % str(test_script), capture=True)
     expected = os.path.realpath(virtualenv.virtualenv).replace(os.sep, "/")
     assert output[:len(expected)].lower() == expected.lower()
+
+
+@pytest.mark.skipif(not Path(DIST_DIR).exists(), reason="dist directory does not exist")
+def test_source_distribution(virtualenv, tmpdir):
+    sdists = Path(DIST_DIR).files(match=matchers.CaseInsensitive("*.tar.gz"))
+    if not sdists:
+        pytest.skip("no source distribution available")
+    assert len(sdists) == 1
+
+    if "SETUP_CMAKE_ARGS" in os.environ:
+        virtualenv.env["SKBUILD_CONFIGURE_OPTIONS"] = os.environ["SETUP_CMAKE_ARGS"]
+    virtualenv.run("pip install %s" % sdists[0])
+    assert "cmake" in virtualenv.installed_packages()
+
+    _check_cmake_install(virtualenv, tmpdir)
 
 
 @pytest.mark.skipif(not Path(DIST_DIR).exists(), reason="dist directory does not exist")

--- a/versioneer.py
+++ b/versioneer.py
@@ -1283,7 +1283,22 @@ def render_pep440_post(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"] or pieces["dirty"]:
-            rendered += ".post%d" % pieces["distance"]
+            if ".post" in rendered:
+                # update the existing post tag
+                start = rendered.index(".post") + 5
+                if len(rendered) == start:
+                    rendered += "%d" % pieces["distance"]
+                else:
+                    end = start + 1
+                    while end <= len(rendered) and rendered[start:end].isdigit():
+                        end += 1
+                    end -= 1
+                    distance = pieces["distance"]
+                    if start != end:
+                        distance += int(rendered[start:end])
+                    rendered = rendered[:start] + "%d" % distance + rendered[end:]
+            else:
+                rendered += ".post%d" % pieces["distance"]
             if pieces["dirty"]:
                 rendered += ".dev0"
             rendered += plus_or_dot(pieces)


### PR DESCRIPTION
Same issues as were found in Ninja distribution https://github.com/scikit-build/ninja-python-distributions/pull/43 when building from sdist:
1. Add a test to build from sdist.
2. Use the same fixes the ones in  https://github.com/scikit-build/ninja-python-distributions/pull/43
2.1 The "import issue" affects all builds from sdist
2.2 The ill-specified version returned by versioneer only impacts ci as it would be impossible to upload the sdist to PyPI 

