### PR TITLE
Deploy a single py2.py3 wheel per platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ references:
             echo "MANYLINUX_PYTHON [${MANYLINUX_PYTHON}]"
             /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci
             /opt/python/${MANYLINUX_PYTHON}/bin/ci
+            if [ "${UPLOAD_SDIST}" == "tests-only" ]; then
+              rm -f ./dist/*
+            fi
       - persist_to_workspace:
           root: ./
           paths:
@@ -44,16 +47,16 @@ references:
 jobs:
 
   # x64
-  manylinux-x64_cp27-cp27mu:
-    <<: *x64_build_job
   manylinux-x64_cp37-cp37m_upload-sdist:
     <<: *x64_build_job
 
   # x86
-  manylinux-x86_cp27-cp27mu:
-    <<: *x86_build_job
   manylinux-x86_cp37-cp37m:
     <<: *x86_build_job
+
+  # python 2.7 tests
+  manylinux-x64_cp27-cp27mu_tests-only:
+    <<: *x64_build_job
 
   deploy-master:
     docker:
@@ -87,35 +90,35 @@ workflows:
   build-test-deploy:
     jobs:
       # x64
-      - manylinux-x64_cp27-cp27mu:
-          <<: *no_filters
       - manylinux-x64_cp37-cp37m_upload-sdist:
           <<: *no_filters
       # x86
-      - manylinux-x86_cp27-cp27mu:
-          <<: *no_filters
       - manylinux-x86_cp37-cp37m:
+          <<: *no_filters
+
+      # python 2.7 tests
+      - manylinux-x64_cp27-cp27mu_tests-only:
           <<: *no_filters
 
       - deploy-master:
           requires:
             # x64
-            - manylinux-x64_cp27-cp27mu
             - manylinux-x64_cp37-cp37m_upload-sdist
             # x86
-            - manylinux-x86_cp27-cp27mu
             - manylinux-x86_cp37-cp37m
+            # python 2.7 test
+            - manylinux-x64_cp27-cp27mu_tests-only
           filters:
             branches:
               only: master
       - deploy-release:
           requires:
             # x64
-            - manylinux-x64_cp27-cp27mu
             - manylinux-x64_cp37-cp37m_upload-sdist
             # x86
-            - manylinux-x86_cp27-cp27mu
             - manylinux-x86_cp37-cp37m
+            # python 2.7 test
+            - manylinux-x64_cp27-cp27mu_tests-only
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,25 @@ jobs:
   manylinux-x64_cp27-cp27mu_tests-only:
     <<: *x64_build_job
 
+  check-dist:
+    docker:
+      - image: cimg/python:3.9.5
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Check dist
+          command: |
+            echo "Check dist"
+            ls dist
+            python -m venv ../venv
+            . ../venv/bin/activate
+            pip install twine
+            twine check --strict dist/*
+
   deploy-master:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: cimg/python:3.9.5
     steps:
       - attach_workspace:
           at: ./
@@ -71,7 +87,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: cimg/python:3.9.5
     steps:
       - attach_workspace:
           at: ./
@@ -100,7 +116,7 @@ workflows:
       - manylinux-x64_cp27-cp27mu_tests-only:
           <<: *no_filters
 
-      - deploy-master:
+      - check-dist:
           requires:
             # x64
             - manylinux-x64_cp37-cp37m_upload-sdist
@@ -108,17 +124,16 @@ workflows:
             - manylinux-x86_cp37-cp37m
             # python 2.7 test
             - manylinux-x64_cp27-cp27mu_tests-only
+
+      - deploy-master:
+          requires:
+            - check-dist
           filters:
             branches:
               only: master
       - deploy-release:
           requires:
-            # x64
-            - manylinux-x64_cp37-cp37m_upload-sdist
-            # x86
-            - manylinux-x86_cp37-cp37m
-            # python 2.7 test
-            - manylinux-x64_cp27-cp27mu_tests-only
+            - check-dist
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,13 +85,17 @@ script:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         ci test
     fi
+    pwd
+    ls dist
+    PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH
+    twine --version
+    twine check --strict dist/*
 
 after_success:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         ci after_test
     fi
-    pwd && ls dist; PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH && twine --version
 
 deploy:
   # deploy-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ matrix:
         - PYTHON_VERSION=3.7.9
         - MACOSX_DEPLOYMENT_TARGET=10.10
 
-    - os: osx
-      language: generic
-      env:
-        - PYTHON_VERSION=2.7.18
-        - MACOSX_DEPLOYMENT_TARGET=10.10
-
     - arch: arm64-graviton2
       virt: vm
       group: edge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,6 @@ version: "0.0.1.{build}"
 environment:
   matrix:
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON_DIR: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-      BLOCK: "0"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON_DIR: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-      BLOCK: "0"
-
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       PYTHON_DIR: "C:\\Python37"
       PYTHON_VERSION: "3.7.x"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,9 @@ build_script:
 
 test_script:
   - "%PYTHON_DIR%\\python.exe -m ci test"
+  - ps: |
+      $env:PATH="$env:PYTHON_DIR/Scripts/;$env:PATH"
+      twine check --strict dist/*
 
 after_test:
   - "%PYTHON_DIR%\\python.exe -m ci after_test"
@@ -48,9 +51,9 @@ on_finish:
 
 deploy_script:
   - ps: |
+      $env:PATH="$env:PYTHON_DIR/Scripts/;$env:PATH"
       if ($env:appveyor_repo_tag -eq $true -and $env:appveyor_repo_tag_name –match "^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$") {
         Write-Host "deploy release"
-        $env:PATH="$env:PYTHON_DIR/Scripts/;$env:PATH"
         twine upload -u $env:PYPI_USER -p $env:PYPI_PASSWORD --skip-existing dist/*
       } elseif ($env:appveyor_repo_branch -eq "master") {
          Write-Host "deploy master (not implemented)"

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -49,7 +49,6 @@ before_install:
                   import os
                   import ci
                   import platform
-                  os.environ["SETUP_BDIST_WHEEL_ARGS"] = "--plat-name %s" % os.environ["AUDITWHEEL_PLAT"]
                   setup_cmake_args = []
                   setup_cmake_args.append("-DSTRIP_EXECUTABLE:FILEPATH=/opt/rh/devtoolset-9/root/usr/" + "/bin/strip")
                   if platform.machine() in {"aarch64", "ppc64le", "s390x"}:
@@ -95,22 +94,19 @@ build:
         - |
           # Since there are no external shared libraries to bundle into the wheels
           # this step will fixup the wheel switching from 'linux' to 'manylinux' tag
-          for whl in dist/*linux*_$(arch).whl; do
-              auditwheel repair --plat ${AUDITWHEEL_PLAT} $whl -w ./dist
+          for whl in dist/*.whl; do
+              auditwheel repair --plat ${AUDITWHEEL_PLAT} ${whl} -w ./dist/
+              rm ${whl}
           done
 
   circle:
     commands:
       - |
-        arch=${AUDITWHEEL_ARCH}
-        if [[ ${arch} == "aarch64" ]]; then
-            exit
-        fi
         # Since there are no external shared libraries to bundle into the wheels
         # this step will fixup the wheel switching from 'linux' to 'manylinux' tag
-        for whl in dist/*linux_${arch}.whl; do
-            auditwheel repair --plat ${AUDITWHEEL_PLAT} $whl -w ./dist/
-            rm $whl
+        for whl in dist/*.whl; do
+            auditwheel repair --plat ${AUDITWHEEL_PLAT} ${whl} -w ./dist/
+            rm ${whl}
         done
 
 test:
@@ -139,7 +135,9 @@ test:
                       additional_platforms.append("macosx_11_0_universal2")
 
               for wheel in wheels:
-                  convert_to_generic_platform_wheel(wheel, remove_original=True, additional_platforms=additional_platforms)
+                  convert_to_generic_platform_wheel(wheel, remove_original=True, py2_py3=True, additional_platforms=additional_platforms)
+              wheels = glob.glob("dist/*.whl")
+              assert len(wheels) == 1, "There shall be exactly 1 final wheel per build"
 
   appveyor:
     commands:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
                 'tools designed to build, test and package software',
 
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/x-rst',
 
     classifiers=[
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Main goal:
- Deploy a single py2.py3 wheel per platform: saves build time, space on PyPI & maybe bandwidth.
  - Update `convert_to_generic_platform_wheel` to convert to a `py2.py3` wheel & update jobs not to have python 2.7 jobs
  - Add a test only python 2.7 job not to introduce regressions for python 2
  - Add a check that only 1 wheel per platform is built/uploaded
    - fix: Only rely on auditwheel to add manylinux* platform tags

Other goals:
- Check the content of the list/* with twine  check on every commit
  - This allowed to fix 2 issues:
    1. The `long_description_content_type` was missing in the metadata
    2. The deployment step on circle-ci would have failed on release