### PR TITLE
refactor: split requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,8 @@ install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         ci install
-    elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        MACHINE=$(uname -m)
-        if [[ "${MACHINE}" == "s390x" ]] || [[ "${MACHINE}" == "ppc64le" ]]; then
-            pip install $(pwd)/cryptography*.whl
-        fi
-        pip install twine
     fi
+    python -m pip install -r requirements-deploy.txt
 
 script:
   - |
@@ -87,7 +82,6 @@ script:
     fi
     pwd
     ls dist
-    PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH
     twine --version
     twine check --strict dist/*
 
@@ -100,7 +94,7 @@ after_success:
 deploy:
   # deploy-release
   - provider: script
-    script: pwd && ls dist;echo "deploy-release" && PATH=~/.pyenv/versions/${PYTHON_VERSION}/bin/:$PATH && twine upload -u $PYPI_USER -p $PYPI_PASSWORD --skip-existing dist/*
+    script: pwd && ls dist;echo "deploy-release" && twine upload -u $PYPI_USER -p $PYPI_PASSWORD --skip-existing dist/*
     skip_cleanup: true
     on:
       repo: ${TRAVIS_REPO_SLUG}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include CMakeLists.txt
 include CMakeUrls.cmake
-include requirements-dev.txt
+include requirements-test.txt
 include HISTORY.rst
 include README.rst
 include LICENSE_Apache_20

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ init:
 
 install:
   - "%PYTHON_DIR%\\python.exe -m ci install"
+  - "%PYTHON_DIR%\\python.exe -m pip install -r requirements-deploy.txt"
 
 build_script:
   - "%PYTHON_DIR%\\python.exe -m ci build"

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,0 +1,6 @@
+twine
+
+# need to pin cryptography for s390x/ppc64le builds:
+# cryptography never provided wheels for those architectures and the
+# requirements to build from sources are relaxed when building the 3.3 series
+cryptography~=3.3.2 ; sys_platform=="linux" and platform_machine in "s390x, ppc64le"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,3 @@
-codecov>=2.0.5
-coverage>=4.2
-flake8>=3.0.4
-path.py>=11.5.0
-pytest>=3.0.3
-pytest-cov>=2.4.0
-pytest-runner>=2.9
-pytest-virtualenv>=1.2.5
-scikit-build>=0.10.0
-setuptools>=28.0.0
-twine
-virtualenv>=15.0.3
-wheel
-wheeltools
-
-# need to pin cryptography for manylinux1 builds
-# cryptography only provides manylinux2010 wheels since 3.4.0
-# because of the lack of a decent rust compiler on manylinux1
-cryptography~=3.3.2 ; sys_platform=="linux" and platform_machine in "i386, i486, i586, i686, x86_64"
+-r requirements-test.txt
+-r requirements-repair.txt
+-r requirements-deploy.txt

--- a/requirements-repair.txt
+++ b/requirements-repair.txt
@@ -1,0 +1,1 @@
+wheeltools @ git+https://github.com/jcfr/wheeltools.git@wheeltools-2018-10-28-a2f174d0e#egg=wheeltools

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,12 @@
+codecov>=2.0.5
+coverage>=4.2
+flake8>=3.0.4
+path.py>=11.5.0
+pytest>=3.0.3
+pytest-cov>=2.4.0
+pytest-runner>=2.9
+pytest-virtualenv>=1.7.0
+scikit-build>=0.10.0
+setuptools>=28.0.0
+virtualenv>=15.0.3
+wheel

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -26,10 +26,6 @@ before_install:
                 # Support using older manylinux images explicitly setting AUDITWHEEL_*  environment variables
                 os.environ["AUDITWHEEL_ARCH"] = manylinux_arch
                 os.environ["AUDITWHEEL_PLAT"] = manylinux_version + "_" + manylinux_arch
-                # CFLAGS
-                if arch == "x86":
-                    # Required to build cryptography wheel from source for cp37-cp37 when using manylinux-x86
-                    os.environ["CFLAGS"] = "-I/usr/local/ssl/include -L/usr/local/ssl/lib"
                 # SETUP_CMAKE_ARGS
                 if arch in ["x86", "x64"]:
                     os.environ["SETUP_CMAKE_ARGS"] = "-DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl " + os.environ["SETUP_CMAKE_ARGS"]
@@ -67,9 +63,7 @@ install:
   commands:
     - python -c "import sys; print(sys.version)"
     - python -m pip install --disable-pip-version-check --upgrade pip
-    - pip install pytest-virtualenv -f https://github.com/jcfr/pytest-plugins/releases/tag/v1.7.0.dev15 --pre
-    - pip install git+https://github.com/jcfr/wheeltools.git@wheeltools-2018-10-28-a2f174d0e
-    - pip install -r requirements-dev.txt
+    - pip install -r requirements-test.txt -r requirements-repair.txt
 
 before_build:
   commands:

--- a/scripts/manylinux2014-build-and-test-wheel.sh
+++ b/scripts/manylinux2014-build-and-test-wheel.sh
@@ -9,17 +9,6 @@ export PATH="${MANYLINUX_PYTHON_BIN}:$PATH"
 cd /io
 ./scripts/manylinux2014-build-and-install-openssl.sh /tmp/openssl-install shared
 
-MACHINE=$(uname -m)
-if [ "${MACHINE}" == "s390x" ] || [ "${MACHINE}" == "ppc64le" ]; then
-    # build cryptography from sources
-    yum install -y libffi-devel
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
-    export PATH=${HOME}/.cargo/bin:${PATH}
-    ./scripts/manylinux2014-build-and-install-openssl.sh /tmp/openssl-cryptography no-shared -fPIC
-    CFLAGS="-I/tmp/openssl-cryptography/include" LDFLAGS="-L/tmp/openssl-cryptography/lib" ${MANYLINUX_PYTHON_BIN}/pip wheel --no-binary :all: cryptography
-    ${MANYLINUX_PYTHON_BIN}/pip install ./cryptography*.whl
-fi
-
 ci_before_install() {
     ${MANYLINUX_PYTHON_BIN}/python scripts/ssl-check.py
     ${MANYLINUX_PYTHON_BIN}/pip install scikit-ci scikit-ci-addons scikit-build

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def parse_requirements(filename):
 
 
 requirements = []
-dev_requirements = parse_requirements('requirements-dev.txt')
+test_requirements = parse_requirements('requirements-test.txt')
 
 # Require pytest-runner only when running tests
 pytest_runner = (['pytest-runner>=2.0,<3dev']
@@ -89,6 +89,6 @@ setup(
     keywords='CMake build c++ fortran cross-platform cross-compilation',
 
     install_requires=requirements,
-    tests_require=dev_requirements,
+    tests_require=test_requirements,
     setup_requires=setup_requires
 )


### PR DESCRIPTION
Pre requisite to #139 to allow installing only what's really needed at a given step.

This works well enough but I'm clearly not a fan of this as-is. Any improvement suggestions are welcome.
