### PR TITLE
ci: pin `ruamel.yaml<0.17.5`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ references:
             #
             export MANYLINUX_PYTHON=$(echo ${CIRCLE_JOB} | cut -d"_" -f2)
             echo "MANYLINUX_PYTHON [${MANYLINUX_PYTHON}]"
-            /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci
+            /opt/python/${MANYLINUX_PYTHON}/bin/pip install scikit-ci 'ruamel.yaml<0.17.5'
             /opt/python/${MANYLINUX_PYTHON}/bin/ci
             if [ "${UPLOAD_SDIST}" == "tests-only" ]; then
               rm -f ./dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        pip install -U scikit-ci scikit-ci-addons
+        pip install -U scikit-ci scikit-ci-addons 'ruamel.yaml<0.17.5'
         ci_addons --install ../addons
     elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         docker run -t --rm \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
     secure: qDoPKmtLMdcKUKRHuTlfaajjzO4Q4yu25FM5JuB7z84=
 
 init:
-  - "%PYTHON_DIR%\\python.exe -m pip install -U scikit-ci scikit-ci-addons"
+  - "%PYTHON_DIR%\\python.exe -m pip install -U scikit-ci scikit-ci-addons ruamel.yaml==0.17.4"
   - "%PYTHON_DIR%\\python.exe -m ci_addons --install ../addons"
 
   - ps: ../addons/appveyor/rolling-build.ps1

--- a/scripts/manylinux2014-build-and-test-wheel.sh
+++ b/scripts/manylinux2014-build-and-test-wheel.sh
@@ -22,7 +22,7 @@ fi
 
 ci_before_install() {
     ${MANYLINUX_PYTHON_BIN}/python scripts/ssl-check.py
-    ${MANYLINUX_PYTHON_BIN}/pip install scikit-ci scikit-ci-addons scikit-build
+    ${MANYLINUX_PYTHON_BIN}/pip install scikit-ci scikit-ci-addons scikit-build  'ruamel.yaml<0.17.5'
 }
 
 ci_install() {


### PR DESCRIPTION
The 0.17.5 version is causing issues in CI.

Given those issues will go away when moving to cibuildwheel, I'd rather pin to `<0.17.5` than investigate this some more.