### PR TITLE
chore: add nox and remove deprecated things

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,24 @@
 name: Build and upload to PyPI
 
 on:
-  push:
+  workflow_dispatch:
   pull_request:
+  push:
+    branches:
+      - master
+      - main
 
 jobs:
-  flake8:
-    name: flake8
+  lint:
+    name: Lint
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: pipx run flake8
+      - run: pipx run nox --forcecolor -s lint
 
   build_wheels:
     name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
-    needs: [flake8]
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -47,7 +51,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    needs: [flake8]
+    needs: [lint]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -108,33 +112,21 @@ jobs:
           name: artifact
           path: dist
 
-      - run: |
-          pipx install twine
-          twine check --strict dist/*
+      - run: pipx run twine check --strict dist/*
 
   upload_pypi:
-    name: Upload to (Test) PyPI
+    name: Upload to PyPI
     needs: [build_wheels, build_sdist, test_sdist, check_dist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'scikit-build/cmake-python-distributions'
+    if: github.event_name == 'push' && github.repository == 'scikit-build/cmake-python-distributions' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v2
         with:
           name: artifact
           path: dist
 
-      - name: Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TEST_PASSWORD }}
-          skip_existing: true
-          repository_url: https://test.pypi.org/legacy/
-
       - name: Upload to PyPI
-        # upload to PyPI on every tag
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_RELEASE_PASSWORD }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -60,17 +60,16 @@ Get Started
 Ready to contribute? Here's how to set up `cmake-python-distributions` for local development.
 
 1. Fork the `cmake-python-distributions` repo on GitHub.
+
 2. Clone your fork locally::
 
     $ git clone git@github.com:your_name_here/cmake-python-distributions.git
 
-3. Install your local copy into a virtualenv. Assuming you have
-   virtualenvwrapper installed (`pip install virtualenvwrapper`), this is how
-   you set up your cloned fork for local development::
+3. Make sure you have ``nox`` installed (preferably use ``pipx`` or ``brew``
+   (macOS) if you have those)::
 
-    $ mkvirtualenv cmake-python-distributions
+    $ pip install nox
     $ cd cmake-python-distributions/
-    $ pip install -r requirements-dev.txt
 
 4. Create a branch for local development::
 
@@ -78,12 +77,10 @@ Ready to contribute? Here's how to set up `cmake-python-distributions` for local
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and
+5. When you're done making changes, check that your changes pass linters and
    the tests::
 
-    $ flake8
-    $ python setup.py bdist_wheel
-    $ python setup.py test
+    $ nox
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/docs/update_cmake_version.rst
+++ b/docs/update_cmake_version.rst
@@ -9,6 +9,18 @@ of CMake associated with the current CMake python distributions.
 
 Available CMake archives can be found at https://cmake.org/files.
 
+Nox prodedure
+-------------
+
+If using nox, run::
+
+    nox -s bump -- <version>
+
+
+And follow the instructions it gives you. Leave off the version to bump to the latest version.
+
+Classic procedure:
+------------------
 
 1. Install `requests`::
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,72 @@
+import nox
+from pathlib import Path
+
+nox.options.sessions = ["lint", "build", "tests"]
+
+BUILD_ENV = {
+    "MACOSX_DEPLOYMENT_TARGET": "10.10",
+}
+
+
+built = ""
+
+
+@nox.session
+def build(session: nox.Session) -> str:
+    """
+    Make an SDist and a wheel. Only runs once.
+    """
+    global built
+    if not built:
+        session.log(
+            "The files produced locally by this job are not intended to be redistributable"
+        )
+        session.install("build")
+        tmpdir = session.create_tmp()
+        session.run("python", "-m", "build", "--outdir", tmpdir, env=BUILD_ENV)
+        (wheel_path,) = Path(tmpdir).glob("*.whl")
+        (sdist_path,) = Path(tmpdir).glob("*.tar.gz")
+        wheel_path.rename(f"dist/{wheel_path.name}")
+        sdist_path.rename(f"dist/{sdist_path.name}")
+        built = wheel_path.name
+    return built
+
+
+@nox.session
+def lint(session: nox.Session) -> str:
+    """
+    Run linters on the codebase.
+    """
+    session.install("flake8")
+    session.run("flake8")
+
+
+@nox.session
+def tests(session: nox.Session) -> str:
+    """
+    Run the tests.
+    """
+    wheel = build(session)
+    session.install(f"./dist/{wheel}[test]")
+    session.run("pytest", *session.posargs)
+
+
+@nox.session
+def docs(session: nox.Session) -> str:
+    """
+    Build the docs.
+    """
+
+    wheel = build(session)
+    session.install("-r", "requirements-docs.txt")
+    session.install(f"./dist/{wheel}")
+
+    session.chdir("docs")
+    session.run("sphinx-build", "-M", "html", ".", "_build")
+
+    if session.posargs:
+        if "serve" in session.posargs:
+            print("Launching docs at http://localhost:8000/ - use Ctrl-C to quit")
+            session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
+        else:
+            print("Unsupported argument to docs")

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,3 +70,19 @@ def docs(session: nox.Session) -> str:
             session.run("python", "-m", "http.server", "8000", "-d", "_build/html")
         else:
             print("Unsupported argument to docs")
+
+
+@nox.session
+def bump(session: nox.Session) -> None:
+    """
+    Set to a new version, use -- <version>, otherwise will use the latest version.
+    """
+    if session.posargs:
+        (version,) = session.posargs
+    else:
+        session.install("lastversion")
+        version = session.run(
+            "lastversion", "kitware/cmake", log=False, silent=True
+        ).strip()
+    session.install("requests")
+    session.run("python", "scripts/update_cmake_version.py", version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ before-all = [
 ]
 before-build = "pip install -r requirements-repair.txt"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
-test-requires = "-r requirements-test.txt"
+test-extras = "test"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.linux]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test = pytest
-
 [flake8]
 max-line-length: 120
 # Whether to display the pep8 instructions on failure (can be quite verbose)
@@ -10,7 +7,7 @@ show-source: True
 # Maximum cyclomatic complexity allowed
 max-complexity: 14
 format: pylint
-exclude: .git,.idea,.eggs,__pycache__,.tox,docs/conf.py,_skbuild,CMake-src,versioneer.py,_version.py
+exclude: .git,.idea,.eggs,__pycache__,.tox,docs/conf.py,_skbuild,CMake-src,versioneer.py,_version.py,.venv,.nox,noxfile.py
 
 [tool:pytest]
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,7 @@ def parse_requirements(filename):
         return TextFile(filename, file).readlines()
 
 
-requirements = []
 test_requirements = parse_requirements('requirements-test.txt')
-
-# Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
-                 if any(arg in sys.argv for arg in ('pytest', 'test'))
-                 else [])
-
-setup_requires = pytest_runner
 
 setup(
     name='cmake',
@@ -88,7 +80,5 @@ setup(
 
     keywords='CMake build c++ fortran cross-platform cross-compilation',
 
-    install_requires=requirements,
-    tests_require=test_requirements,
-    setup_requires=setup_requires
+    extras_require={"test": test_requirements},
 )


### PR DESCRIPTION
This removes `test_requires` and `setup_requires`, as they are deprecated. This also adds nox, making it easier for new contributors to get started, as well as simplifying some tasks. Bumping to the latest version can now be done with `nox -s bump`!
