### PR TITLE
ci: use GHA to build aarch64, ppc64le & s390x wheels on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,13 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      use_qemu:
+        description: 'Use qemu to build linux aarch64, ppc64le & s390x'
+        required: true
+        default: true
+  schedule:
+    - cron: '0 18 * * 5'  # "At 18:00 on Friday."
   pull_request:
   push:
     branches:
@@ -9,6 +16,9 @@ on:
       - main
     tags:
       - "*.*.*"
+
+env:
+  USE_QEMU: ${{ fromJSON(github.event.inputs.use_qemu || 'false') || (github.event_name == 'schedule') || startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   lint:
@@ -32,26 +42,47 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: "x86_64"
+            use_qemu: false
           - os: ubuntu-20.04
             arch: "i686"
+            use_qemu: false
+          - os: ubuntu-20.04
+            arch: "aarch64"
+            use_qemu: true
+          - os: ubuntu-20.04
+            arch: "ppc64le"
+            use_qemu: true
+          - os: ubuntu-20.04
+            arch: "s390x"
+            use_qemu: true
           - os: windows-2019
             arch: "AMD64"
+            use_qemu: false
           - os: windows-2019
             arch: "x86"
+            use_qemu: false
           - os: macos-10.15
             arch: "x86_64"
+            use_qemu: false
 
     steps:
       - uses: actions/checkout@v2
+        if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         with:
           fetch-depth: 0  # required for versioneer to find tags
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+        if: matrix.use_qemu && fromJSON(env.USE_QEMU)
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.0.0a4
+        if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
 
       - uses: actions/upload-artifact@v2
+        if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         with:
           path: ./wheelhouse/*.whl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 branches:
  only:
   - master
-  - /^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$/
+  - main
 
 os: linux
 dist: focal
 language: python
 python: "3.8"
-
-env:
-  global:
-    # PYPI_USER
-    - secure: "Xejg5qGnAyo3G+/TaaAr1uHzDv9GLo3mxi6Aw/hZc9gF9lYix1TvkfE6GEBKdPgSLJSqF9NJrwKTt37XH1DjSRLG+qw6Bt1goi5Bkugdk+SC5qmMkvAoG0EKyD119WS4ObrpzqAFcOQqG+4F6iDkSuJLA+dzA3yAzTME4pkhr/2dn0krOSqIcTlgifPwhEaMgo//WRT2dEBM5dWoehXsEMD7VMOUyC0DlV15lKTPKSzTrDEUPU7UFnXgIqZM/brEPbWPQr5Jzgu7BeBk6bmPiiYeh28Cq2juzOzA+JWcGgJmXOfsImYwYuAWZrf0pkE0uQjLySvIBKT7phJv05eNqIxmv/wHK1BPcyMV+2IgFR4+f5ty6C4VUV0hT0HvHr3pMa/8A/5wSNCShEAMTHrwPM5VPWFJtUKTtS5+wwNQDI39MLk/vr9ZTo+y3WJHPaRR0nRpbA3nXFHSqoJJunoMyeI8x9cXZvJ9IENMxGuo3CfBT5RGZamfqSTgn6NjL51ArIMKpvUfm3tXTtlvCHenED1ZQeJI1nWZEalxl8pTyAZoA8S1+h8wraZrUPzhM0QuVpw7vZQeOYu2VSdHO46yxUWoQyb+JWrDTN7EC8vOl7QQzIQlqOWJB5uDJD7UlKKtneTHJrdfXvGxS/hf+Y+hFZK7r+/PDPS6aQjSNDyy+js="
-    # PYPI_PASSWORD
-    - secure: "iEHYaOC/yivDupsbRzohWYCwFMZbCfT2hYOM96akQtOfd1d37rqFCFjDKr3BNyvHyHzj+uNQ7IblynWAqu3cax2Z8b9YuIFXFAslD76IIgeIhxmi8jPtamMK0NBXam/LEL49EIVXUnwVZrWjnLcJxVaBHGS/9Ft3zWP5Gspa4G1yAJDhNfs+jrFipxO4DOBie9mGI2jFdbFRgcCYoY6Jo4y95zxUG1YF5e+8sUobLoBgVqyaJP4SP/Zu/4CEWMfJev8EjLBzzkoPwOU+hC09qwf2FQCvBXFrudpjPpY23WDFeKf+LcMoW9tIoUmP6UJcQibqHeidimrbo9jST0+wTo1NYjrvriKrlMho/QS4iYkd5N6DGUrhSXEMSiqfdMjVGDZ00wvCsT3DwqE9eG7K+Kw09enchjcZcggZIt9crqZPJg3GMdSwPYTlRpf2OQmE4OHL3pN5dSH5Es/sb0X1G6JQgB/2Ia9Aks2ywYEdzUZhbMqfLVx75bVS4bLfYMAMhE/j7NxpYaUlVkFhz3srLhnrYyAcvCQ6XF4cSeFfxD1ie62/qFIF/QH5u76t91uURHygvNdyJCNHhVJnnWgN9kPsJxfyfdOC2Dnrz/jJcw5irsgQVO2/K4iyGyBVoOqwwpymjoCkxB8capEoLRNLcwyQqCTBnMtGykyRYF2I7FA="
-
 matrix:
   include:
     - arch: arm64-graviton2
@@ -33,19 +25,3 @@ script:
     ls dist
     twine --version
     twine check --strict dist/*
-
-deploy:
-  # deploy-release
-  - provider: script
-    script: pwd && ls dist;echo "deploy-release" && twine upload -u $PYPI_USER -p $PYPI_PASSWORD --skip-existing dist/*
-    skip_cleanup: true
-    on:
-      repo: ${TRAVIS_REPO_SLUG}
-      tags: true
-  # deploy-master
-  - provider: script
-    script: pwd && ls dist;echo "deploy-master" && echo "not implemented"
-    skip_cleanup: true
-    on:
-      repo: ${TRAVIS_REPO_SLUG}
-      branch: master


### PR DESCRIPTION
use GHA to build aarch64, ppc64le & s390x wheels on tag
- also setup a scheduled run of the workflow to check aarch64, ppc64le & s390x builds
- allow manually dispatched workflow to check aarch64, ppc64le & s390x builds

partial fix to #159 