### PR TITLE
chore: update cibuildwheel from 2.0.0a4 to 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: matrix.use_qemu && fromJSON(env.USE_QEMU)
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.0.0a4
+        uses: pypa/cibuildwheel@v2.0.0
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - arch: s390x
 
 install:
-  - python -m pip install cibuildwheel==2.0.0a4
+  - python -m pip install cibuildwheel==2.0.0
   - python -m pip install -r requirements-deploy.txt
 
 script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,8 @@ before-all = [
     "./scripts/manylinux-build-and-install-openssl.sh",
 ]
 build-verbosity = "1"
-manylinux-x86_64-image = "quay.io/pypa/manylinux1_x86_64:2021-07-04-13bcf48"
-manylinux-i686-image = "quay.io/pypa/manylinux1_i686:2021-07-04-13bcf48"
-manylinux-aarch64-image = "quay.io/pypa/manylinux2014_aarch64:2021-07-04-1e3ce39"
-manylinux-ppc64le-image = "quay.io/pypa/manylinux2014_ppc64le:2021-07-04-1e3ce39"
-manylinux-s390x-image = "quay.io/pypa/manylinux2014_s390x:2021-07-04-1e3ce39"
+manylinux-x86_64-image = "manylinux1"
+manylinux-i686-image = "manylinux1"
 
 [tool.cibuildwheel.linux.environment]
 SKBUILD_CONFIGURE_OPTIONS = "-DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl -DCMAKE_JOB_POOL_COMPILE:STRING=compile -DCMAKE_JOB_POOL_LINK:STRING=link -DCMAKE_JOB_POOLS:STRING=compile=2;link=1"


### PR DESCRIPTION
release notes: https://github.com/pypa/cibuildwheel/releases/tag/v2.0.0