### PR TITLE
fix: libuv now respect `CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
           BINARY_DIR ${LibUV_BINARY_DIR}
           URL "https://dist.libuv.org/dist/v1.23.0/libuv-v1.23.0.tar.gz"
           URL_HASH "SHA256=d1746d324dea973d9f4c7ff40ba9cf60556c0bae9a92ad970568211b0e3bce27"
+          DOWNLOAD_DIR ${CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR}
           ${_common_args}
           CMAKE_CACHE_ARGS
             ${_common_cache_args}


### PR DESCRIPTION
When building from sources on Linux, libuv didn't respect `CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR` preventing building the sdist without an internet connection.
It is now respected allowing to build the sdist with:
```
SKBUILD_CONFIGURE_OPTIONS="-DCMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR:PATH=$(pwd)/downloads" pip wheel -v cmake-3.21.1.tar.gz
```
assuming cmake & llibuv source archives are available in `$(pwd)/downloads`

fix #172