### PR TITLE
chore: only use custom libuv for glibc<2.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,33 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
+  build_manylinux1_wheels:
+    name: Build ${{ matrix.arch }} manylinux1 wheels
+    needs: [lint]
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: "x86_64"
+          - arch: "i686"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # required for versioneer to find tags
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.0.1
+        env:
+          CIBW_ARCHS: "${{ matrix.arch }}"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux1"
+          CIBW_MANYLINUX_I686_IMAGE: "manylinux1"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: Build source distribution
     needs: [lint]
@@ -139,7 +166,7 @@ jobs:
 
   check_dist:
     name: Check dist
-    needs: [build_wheels, build_sdist, test_sdist]
+    needs: [build_wheels, build_manylinux1_wheels, build_sdist, test_sdist]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v2
@@ -151,7 +178,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_wheels, build_sdist, test_sdist, check_dist]
+    needs: [build_wheels, build_manylinux1_wheels, build_sdist, test_sdist, check_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'scikit-build/cmake-python-distributions' && startsWith(github.ref, 'refs/tags/')
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,25 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
       set(_cmake_cache_args)
 
       # libuv
+      set(UseCustomLibUV OFF)
       if(UNIX AND NOT APPLE)
+        # libuv 1.23.0 is the last version to build on CentOS 5 (or glibc < 2.12)
+        # Use libuv 1.23.0 instead of cmake embedded libuv when detecting glibc < 2.12
+        # https://github.com/libuv/libuv/blob/v1.x/SUPPORTED_PLATFORMS.md
+        include(CheckSymbolExists)
+        check_symbol_exists(__GLIBC__ "stdlib.h" HAS_GLIBC_MAJOR)
+        check_symbol_exists(__GLIBC_MINOR__ "stdlib.h" HAS_GLIBC_MINOR)
+        if(HAS_GLIBC_MAJOR AND HAS_GLIBC_MINOR AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+          execute_process(COMMAND echo __GLIBC__ COMMAND "${CMAKE_CXX_COMPILER}" -E -P -imacros stdlib.h - OUTPUT_VARIABLE GLIBC_MAJOR_)
+          string(STRIP "${GLIBC_MAJOR_}" GLIBC_MAJOR)
+          execute_process(COMMAND echo __GLIBC_MINOR__ COMMAND "${CMAKE_CXX_COMPILER}" -E -P -imacros stdlib.h - OUTPUT_VARIABLE GLIBC_MINOR_)
+          string(STRIP "${GLIBC_MINOR_}" GLIBC_MINOR)
+          if("${GLIBC_MAJOR}.${GLIBC_MINOR}" VERSION_LESS "2.12")
+            set(UseCustomLibUV ON)
+          endif()
+        endif()
+      endif()
+      if(UseCustomLibUV)
         set(LibUV_SOURCE_DIR ${CMAKE_BINARY_DIR}/LibUV-src)
         set(LibUV_BINARY_DIR ${CMAKE_BINARY_DIR}/LibUV-build)
         set(LibUV_INSTALL_DIR ${CMAKE_BINARY_DIR}/LibUV-install)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ before-all = [
     "ninja --version",
     "./scripts/manylinux-build-and-install-openssl.sh",
 ]
-manylinux-x86_64-image = "manylinux1"
-manylinux-i686-image = "manylinux1"
 
 [tool.cibuildwheel.linux.environment]
 SKBUILD_CONFIGURE_OPTIONS = "-DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl -DCMAKE_JOB_POOL_COMPILE:STRING=compile -DCMAKE_JOB_POOL_LINK:STRING=link -DCMAKE_JOB_POOLS:STRING=compile=2;link=1"


### PR DESCRIPTION
CMake provides a much more recent libuv than we're currently building.
1.23.0 is the last version to build on CentOS 5
There's no reason to be stuck with this version when building from sdist or when building on manylinux2010+
Relying on the version embedded in CMake seems much safer than using this old version.

For now, the embedded version is used only when building on glibc>=2.12 to keep the same behavior on other UNIX flavors.
I guess we could maybe do the opposite and only use 1.23.0 when detecting glibc < 2.12 but otherwise always use the embedded one.

This also raises 1 question:
- should manylinux2010 wheels be built in addition to manylinux1 wheels ? (as I guess dropping manylinux1 is not an option here)
