### PR TITLE
feat: build musllinux_1_1 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
 
   build_wheels:
-    name: Build ${{ matrix.arch }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.build }}${{ matrix.arch }} wheels on ${{ matrix.os }}
     needs: [lint]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,27 +40,47 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: "x86_64"
+            build: ""
             use_qemu: false
           - os: ubuntu-20.04
             arch: "i686"
+            build: ""
             use_qemu: false
           - os: ubuntu-20.04
             arch: "aarch64"
+            build: "manylinux_"
+            use_qemu: true
+          - os: ubuntu-20.04
+            arch: "aarch64"
+            build: "musllinux_"
             use_qemu: true
           - os: ubuntu-20.04
             arch: "ppc64le"
+            build: "manylinux_"
+            use_qemu: true
+          - os: ubuntu-20.04
+            arch: "ppc64le"
+            build: "musllinux_"
             use_qemu: true
           - os: ubuntu-20.04
             arch: "s390x"
+            build: "manylinux_"
+            use_qemu: true
+          - os: ubuntu-20.04
+            arch: "s390x"
+            build: "musllinux_"
             use_qemu: true
           - os: windows-2019
             arch: "AMD64"
+            build: ""
             use_qemu: false
           - os: windows-2019
             arch: "x86"
+            build: ""
             use_qemu: false
           - os: macos-10.15
             arch: "x86_64"
+            build: ""
             use_qemu: false
 
     steps:
@@ -74,10 +94,11 @@ jobs:
         if: matrix.use_qemu && fromJSON(env.USE_QEMU)
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.2.0a1
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
+          CIBW_BUILD: "cp39-${{ matrix.build }}*"
 
       - uses: actions/upload-artifact@v2
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
@@ -101,9 +122,11 @@ jobs:
           fetch-depth: 0  # required for versioneer to find tags
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.0.1
+        uses: pypa/cibuildwheel@v2.2.0a1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
+          CIBW_BEFORE_ALL: "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" cmake && pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" ninja && ./scripts/manylinux-build-and-install-openssl.sh"
+          CIBW_BUILD: "cp39-manylinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux1"
           CIBW_MANYLINUX_I686_IMAGE: "manylinux1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - arch: s390x
 
 install:
-  - python -m pip install cibuildwheel==2.1.1
+  - python -m pip install cibuildwheel==2.2.0a1
   - python -m pip install -r requirements-deploy.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
 script:
   - |
+    set -e
     cibuildwheel --output-dir dist
     ls dist
     twine --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ build-verbosity = "1"
 
 [tool.cibuildwheel.linux]
 before-all = [
-    "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" cmake",
-    "cmake --version",
     "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" ninja",
     "ninja --version",
     "./scripts/manylinux-build-and-install-openssl.sh",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ before-all = [
 before-build = "pip install -r requirements-repair.txt"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-extras = "test"
-test-command = "pytest {project}/tests"
+test-command = "pytest --ignore={project}/tests/test_distribution.py {project}/tests"
 build-verbosity = "1"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
This adds musllinux wheel builds in CI workflows.

Still a draft while waiting for upstream cibuildwheel support
- [x] cibuildwheel support for musllinux https://github.com/pypa/cibuildwheel/pull/768
- [x] cibuildwheel release
- [ ] nice to have: https://github.com/pypa/cibuildwheel/discussions/799

We can't use `pipx install -f --pip-args="-c {project}/constraints-ci.txt" cmake` on musllinux for now.
This would require installing openssl-dev as a pre-step.
With https://github.com/pypa/cibuildwheel/discussions/799, we could do either one of the following:
```toml
[[tool.cibuildwheel.overrides]]
build = "cp39-musllinux*"
before-all = [
    "apk install openssl-dev",
    "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" cmake",
    "cmake --version",
    "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" ninja",
    "ninja --version",
    "./scripts/manylinux-build-and-install-openssl.sh",
]
```
or using the pre-installed cmake in musllinux images:
```toml
[[tool.cibuildwheel.overrides]]
build = "cp39-musllinux*"
before-all = [
    "cmake --version",
    "pipx install -f --pip-args=\"-c {project}/constraints-ci.txt\" ninja",
    "ninja --version",
    "./scripts/manylinux-build-and-install-openssl.sh",
]
```
Instead, we rely on manylinux/musllinux images provided cmake, except on manylinux1 where it's not installed. We can go back to forcing a specific version of cmake once we have one batch of musllinux wheels published on PyPI.