### PR TITLE
fix(ci): do no run tests on wheel in sdist tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           SKBUILD_CONFIGURE_OPTIONS: "-DBUILD_CMAKE_FROM_SOURCE:BOOL=OFF"
         run: |
           pip install dist/*.tar.gz
-          rm dist/*.tar.gz
+          rm -rf dist
 
       - name: Test installed SDist
         run: pytest ./tests


### PR DESCRIPTION
there's a race condition in the workflow that allows test_sdist tests to run with wheels present in the dist folder which will fail.