### PR TITLE
Update to cmake 3.23.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,8 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  build_manylinux1_wheels:
-    name: Build ${{ matrix.arch }} manylinux1 wheels
+  build_manylinux2010_wheels:
+    name: Build ${{ matrix.arch }} manylinux2010 wheels
     needs: [lint]
     runs-on: ubuntu-20.04
     strategy:
@@ -136,8 +136,8 @@ jobs:
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "cp39-manylinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux1"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux1"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
+          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -198,7 +198,7 @@ jobs:
 
   check_dist:
     name: Check dist
-    needs: [build_wheels, build_manylinux1_wheels, build_sdist, test_sdist]
+    needs: [build_wheels, build_manylinux2010_wheels, build_sdist, test_sdist]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v3
@@ -210,7 +210,7 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_wheels, build_manylinux1_wheels, build_sdist, test_sdist, check_dist]
+    needs: [build_wheels, build_manylinux2010_wheels, build_sdist, test_sdist, check_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'scikit-build/cmake-python-distributions' && startsWith(github.ref, 'refs/tags/')
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,11 +206,11 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
       # cache arguments for CMake
       set(_cmake_cache_args)
 
-      # libuv
+      # libuv / glibc check
       set(UseCustomLibUV OFF)
       if(UNIX AND NOT APPLE)
-        # libuv 1.23.0 is the last version to build on CentOS 5 (or glibc < 2.12)
-        # Use libuv 1.23.0 instead of cmake embedded libuv when detecting glibc < 2.12
+        # as of CMake 3.23.0, the minimum supported version of libuv is 1.28.0.
+        # this implies that the minimum supported glibc version is 2.12
         # https://github.com/libuv/libuv/blob/v1.x/SUPPORTED_PLATFORMS.md
         include(CheckSymbolExists)
         check_symbol_exists(__GLIBC__ "stdlib.h" HAS_GLIBC_MAJOR)
@@ -221,7 +221,8 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
           execute_process(COMMAND echo __GLIBC_MINOR__ COMMAND "${CMAKE_CXX_COMPILER}" -E -P -imacros stdlib.h - OUTPUT_VARIABLE GLIBC_MINOR_)
           string(STRIP "${GLIBC_MINOR_}" GLIBC_MINOR)
           if("${GLIBC_MAJOR}.${GLIBC_MINOR}" VERSION_LESS "2.12")
-            set(UseCustomLibUV ON)
+            # set(UseCustomLibUV ON)
+            message(FATAL_ERROR "GLIBC ${GLIBC_MAJOR}.${GLIBC_MINOR} not supported")
           endif()
         endif()
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,50 +164,7 @@ if(CMakePythonDistributions_SUPERBUILD)
     #
     if(NOT DEFINED CMakeProject_BINARY_DIR)
 
-      # cache arguments common to LibUV and CMake
-      set(_common_cache_args)
-      if(DEFINED CMAKE_BUILD_TYPE)
-        list(APPEND _common_cache_args
-          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-          )
-      endif()
-      if(DEFINED CMAKE_TOOLCHAIN_FILE)
-        list(APPEND _common_cache_args
-          -DCMAKE_TOOLCHAIN_FILE:STRING=${CMAKE_TOOLCHAIN_FILE}
-          )
-      endif()
-      foreach(var_name IN ITEMS
-        CMAKE_BUILD_PARALLEL_LEVEL
-        CMAKE_JOB_POOLS
-        CMAKE_JOB_POOL_COMPILE
-        CMAKE_JOB_POOL_LINK
-        )
-        if(DEFINED ${var_name})
-          list(APPEND _common_cache_args
-            -D${var_name}:STRING=${${var_name}}
-            )
-          message(STATUS "SuperBuild -   CMakeProject-build - ${var_name}: ${${var_name}}")
-        endif()
-      endforeach()
-
-      set(_common_args )
-      if(UNIX AND (NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
-        # Since CMAKE_C_FLAGS and CMAKE_EXE_LINKER_FLAGS arguments contain spaces, we generate an initial
-        # cache file.
-        file(WRITE "${CMAKE_BINARY_DIR}/initial-cache.txt"
-"set(CMAKE_C_FLAGS \"-D_POSIX_C_SOURCE=199506L -D_POSIX_SOURCE=1 -D_SVID_SOURCE=1 -D_BSD_SOURCE=1\" CACHE STRING \"Initial cache\" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\" FORCE)
-")
-        set(_common_args
-          CMAKE_ARGS -C "${CMAKE_BINARY_DIR}/initial-cache.txt"
-          )
-      endif()
-
-      # cache arguments for CMake
-      set(_cmake_cache_args)
-
-      # libuv / glibc check
-      set(UseCustomLibUV OFF)
+      # glibc check
       if(UNIX AND NOT APPLE)
         # as of CMake 3.23.0, the minimum supported version of libuv is 1.28.0.
         # this implies that the minimum supported glibc version is 2.12
@@ -221,43 +178,36 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
           execute_process(COMMAND echo __GLIBC_MINOR__ COMMAND "${CMAKE_CXX_COMPILER}" -E -P -imacros stdlib.h - OUTPUT_VARIABLE GLIBC_MINOR_)
           string(STRIP "${GLIBC_MINOR_}" GLIBC_MINOR)
           if("${GLIBC_MAJOR}.${GLIBC_MINOR}" VERSION_LESS "2.12")
-            # set(UseCustomLibUV ON)
             message(FATAL_ERROR "GLIBC ${GLIBC_MAJOR}.${GLIBC_MINOR} not supported")
           endif()
         endif()
       endif()
-      if(UseCustomLibUV)
-        set(LibUV_SOURCE_DIR ${CMAKE_BINARY_DIR}/LibUV-src)
-        set(LibUV_BINARY_DIR ${CMAKE_BINARY_DIR}/LibUV-build)
-        set(LibUV_INSTALL_DIR ${CMAKE_BINARY_DIR}/LibUV-install)
 
-        ExternalProject_add(LibUV
-          SOURCE_DIR ${LibUV_SOURCE_DIR}
-          BINARY_DIR ${LibUV_BINARY_DIR}
-          URL "https://dist.libuv.org/dist/v1.23.0/libuv-v1.23.0.tar.gz"
-          URL_HASH "SHA256=d1746d324dea973d9f4c7ff40ba9cf60556c0bae9a92ad970568211b0e3bce27"
-          DOWNLOAD_DIR ${CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR}
-          ${_common_args}
-          CMAKE_CACHE_ARGS
-            ${_common_cache_args}
-            -DCMAKE_INSTALL_PREFIX:PATH=${LibUV_INSTALL_DIR}
-            -DCMAKE_INSTALL_LIBDIR:STRING=lib
-          USES_TERMINAL_CONFIGURE 1
-          USES_TERMINAL_BUILD 1
-          ${ep_log_configure_build_args}
-          INSTALL_DIR ${LibUV_INSTALL_DIR}
-          )
+      # cmake cache arguments
+      set(_cmake_cache_args)
+      if(DEFINED CMAKE_BUILD_TYPE)
         list(APPEND _cmake_cache_args
-          -DCMAKE_USE_SYSTEM_LIBRARY_LIBUV:BOOL=ON
-          -DLibUV_LIBRARY:FILEPATH=${LibUV_INSTALL_DIR}/lib/libuv_a.a
-          -DLibUV_INCLUDE_DIR:PATH=${LibUV_INSTALL_DIR}/include
+          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
           )
-      else()
-        cpd_ExternalProject_Add_Empty(LibUV "")
       endif()
-
-      # cmake
-      set(CMakeProject_BINARY_DIR ${CMAKE_BINARY_DIR}/CMakeProject-build)
+      if(DEFINED CMAKE_TOOLCHAIN_FILE)
+        list(APPEND _cmake_cache_args
+          -DCMAKE_TOOLCHAIN_FILE:STRING=${CMAKE_TOOLCHAIN_FILE}
+          )
+      endif()
+      foreach(var_name IN ITEMS
+        CMAKE_BUILD_PARALLEL_LEVEL
+        CMAKE_JOB_POOLS
+        CMAKE_JOB_POOL_COMPILE
+        CMAKE_JOB_POOL_LINK
+        )
+        if(DEFINED ${var_name})
+          list(APPEND _cmake_cache_args
+            -D${var_name}:STRING=${${var_name}}
+            )
+          message(STATUS "SuperBuild -   CMakeProject-build - ${var_name}: ${${var_name}}")
+        endif()
+      endforeach()
 
       if(DEFINED OPENSSL_ROOT_DIR)
         list(APPEND _cmake_cache_args
@@ -273,20 +223,35 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
         message(STATUS "SuperBuild -   CMakeProject-build - CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
       endif()
 
+      set(_cmake_args )
+      if(UNIX AND (NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
+        # Since CMAKE_C_FLAGS and CMAKE_EXE_LINKER_FLAGS arguments contain spaces, we generate an initial
+        # cache file.
+        file(WRITE "${CMAKE_BINARY_DIR}/initial-cache.txt"
+"set(CMAKE_C_FLAGS \"-D_POSIX_C_SOURCE=199506L -D_POSIX_SOURCE=1 -D_SVID_SOURCE=1 -D_BSD_SOURCE=1\" CACHE STRING \"Initial cache\" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\" FORCE)
+")
+        set(_cmake_args
+          CMAKE_ARGS -C "${CMAKE_BINARY_DIR}/initial-cache.txt"
+          )
+      endif()
+
+      # cmake
+      set(CMakeProject_BINARY_DIR ${CMAKE_BINARY_DIR}/CMakeProject-build)
+
       ExternalProject_add(CMakeProject-build
         SOURCE_DIR ${CMakeProject_SOURCE_DIR}
         BINARY_DIR ${CMakeProject_BINARY_DIR}
         DOWNLOAD_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_ALWAYS 1
-        ${_common_args}
+        ${_cmake_args}
         CMAKE_CACHE_ARGS
           -DBUILD_CursesDialog:BOOL=OFF
           -DCMAKE_USE_OPENSSL:BOOL=ON
           -DBUILD_TESTING:BOOL=ON
           -DCMake_INSTALL_DEPENDENCIES:BOOL=ON
           -DCMAKE_INSTALL_MESSAGE:STRING=NEVER
-          ${_common_cache_args}
           ${_cmake_cache_args}
         USES_TERMINAL_CONFIGURE 1
         USES_TERMINAL_BUILD 1
@@ -294,7 +259,6 @@ set(CMAKE_EXE_LINKER_FLAGS \"-lstdc++ -lgcc -lrt\" CACHE STRING \"Initial cache\
         INSTALL_COMMAND ""
         DEPENDS
           CMakeProject-src-download
-          LibUV
         )
 
         set(CMAKEPROJECT_BUILD_LAST_STEP "build")

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url          "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6.tar.gz")
-set(unix_source_sha256       "73933163670ea4ea95c231549007b0c7243282293506a2cf4443714826ad5ec3")
+set(unix_source_url          "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.tar.gz")
+set(unix_source_sha256       "06fefaf0ad94989724b56f733093c2623f6f84356e5beb955957f9ce3ee28809")
 
-set(windows_source_url       "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6.zip")
-set(windows_source_sha256    "e878cdaf2a8a0aac5c8ec8d5e1df1c5abd0d307ea9b9be2008ac56e2e8077cfb")
+set(windows_source_url       "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.zip")
+set(windows_source_sha256    "1b023cedab15fb384e6617f54f181bd4bcf1ececb40cbb12985b573fa96ee299")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,14 +13,14 @@ set(windows_source_sha256    "e878cdaf2a8a0aac5c8ec8d5e1df1c5abd0d307ea9b9be2008
 set(linux32_binary_url       "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256    "NA")
 
-set(linux64_binary_url       "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-linux-x86_64.tar.gz")
-set(linux64_binary_sha256    "09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc")
+set(linux64_binary_url       "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-linux-x86_64.tar.gz")
+set(linux64_binary_sha256    "39e1c2eccda989b0d000dc5f4ee2cb031bdda799163780d855acc0bd9eda9d92")
 
-set(macos10_10_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-macos10.10-universal.tar.gz")
-set(macos10_10_binary_sha256 "873d296000b2fbd5cd306a3455fddc254b485cad988c67bf4ee0ba4fd7a1e057")
+set(macos10_10_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-macos10.10-universal.tar.gz")
+set(macos10_10_binary_sha256 "b9f6c3c51d437a08f20df2f34a6f65658bd837d6a299cf2e4e583c81484e8f9c")
 
-set(win32_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-windows-i386.zip")
-set(win32_binary_sha256      "058572b13af626e48cc8cba235c14491117b761354fb3c567b11c29835ff8283")
+set(win32_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-windows-i386.zip")
+set(win32_binary_sha256      "5c6fe36122e0ba41baadd0eb80157f107d2cca39894df22e472fcced9542358d")
 
-set(win64_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-windows-x86_64.zip")
-set(win64_binary_sha256      "48bcc3e71e918b72e2682f9ca9d44dd6c416379071c1ecb530d0633374f91f15")
+set(win64_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3-windows-x86_64.zip")
+set(win64_binary_sha256      "b3365f30fc9fb27ffa524c2a987c34b307382930007341b39d3f0e271930d883")

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ The following platforms are supported with binary wheels:
   | macOS 11+     | Apple Silicon            |
   +---------------+--------------------------+
 
+The last version to provide ``manylinux1`` wheels was ``3.22.x``.
+
 Maintainers
 -----------
 

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ The following platforms are supported with binary wheels:
   | Windows       | | 64-bit                 |
   |               | | 32-bit                 |
   +---------------+--------------------------+
-  | Linux Intel   | | manylinux1+ 64-bit     |
+  | Linux Intel   | | manylinux2010+ 64-bit  |
   |               | | musllinux 64-bit       |
-  |               | | manylinux1+ 32-bit     |
+  |               | | manylinux2010+ 32-bit  |
   |               | | musllinux 32-bit       |
   +---------------+--------------------------+
   | Linux ARM     | | manylinux2014+ AArch64 |

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.22.6 <https://cmake.org/cmake/help/v3.22/index.html>`_.
+The CMake python wheels provide `CMake 3.23.3 <https://cmake.org/cmake/help/v3.23/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://www.itk.org>`_ and `VTK <http://www.vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.22.6 <https://cmake.org/cmake/help/v3.22/index.html>`_.
+The CMake python wheels provide `CMake 3.23.3 <https://cmake.org/cmake/help/v3.23/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/update_cmake_version.rst
+++ b/docs/update_cmake_version.rst
@@ -29,13 +29,13 @@ Classic procedure:
 2. Execute `scripts/update_cmake_version.py` command line tool with the desired
    ``X.Y.Z`` CMake version available for download. For example::
 
-    $ release=3.22.6
+    $ release=3.23.3
     $ ./scripts/update_cmake_version.py $release
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.22.6'
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.23.3'
     [...]
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.22.6' - done
-    Updating 'CMakeUrls.cmake' with CMake version 3.22.6
-    Updating 'CMakeUrls.cmake' with CMake version 3.22.6 - done
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.23.3' - done
+    Updating 'CMakeUrls.cmake' with CMake version 3.23.3
+    Updating 'CMakeUrls.cmake' with CMake version 3.23.3 - done
     Updating docs/index.rst
     Updating docs/index.rst - done
     Updating README.rst
@@ -46,7 +46,7 @@ Classic procedure:
 3. Create a topic named `update-to-cmake-X.Y.Z` and commit the changes.
    For example::
 
-    release=3.22.6
+    release=3.23.3
     git switch -c update-to-cmake-$release
     git add -u CMakeUrls.cmake docs/index.rst README.rst tests/test_distribution.py docs/update_cmake_version.rst
     git commit -m "Update to CMake $release"

--- a/setup.py
+++ b/setup.py
@@ -29,59 +29,142 @@ def parse_requirements(filename):
 
 test_requirements = parse_requirements('requirements-test.txt')
 
-setup(
-    name='cmake',
+try:  # noqa: C901
+    setup(
+        name='cmake',
 
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
 
-    author='Jean-Christophe Fillion-Robin',
-    author_email='jchris.fillionr@kitware.com',
+        author='Jean-Christophe Fillion-Robin',
+        author_email='jchris.fillionr@kitware.com',
 
-    package_dir={'': 'src'},
-    packages=['cmake'],
+        package_dir={'': 'src'},
+        packages=['cmake'],
 
-    cmake_install_dir='src/cmake/data',
+        cmake_install_dir='src/cmake/data',
 
-    entry_points={
-        'console_scripts': [
-            'cmake=cmake:cmake', 'cpack=cmake:cpack', 'ctest=cmake:ctest'
-        ]
-    },
+        entry_points={
+            'console_scripts': [
+                'cmake=cmake:cmake', 'cpack=cmake:cpack', 'ctest=cmake:ctest'
+            ]
+        },
 
-    url='https://cmake.org/',
-    download_url='https://cmake.org/download',
-    project_urls={
-        "Documentation": "https://cmake-python-distributions.readthedocs.io/",
-        "Source Code": "https://github.com/scikit-build/cmake-python-distributions",
-        "Mailing list": "https://groups.google.com/forum/#!forum/scikit-build",
-        "Bug Tracker": "https://github.com/scikit-build/cmake-python-distributions/issues",
-    },
+        url='https://cmake.org/',
+        download_url='https://cmake.org/download',
+        project_urls={
+            "Documentation": "https://cmake-python-distributions.readthedocs.io/",
+            "Source Code": "https://github.com/scikit-build/cmake-python-distributions",
+            "Mailing list": "https://groups.google.com/forum/#!forum/scikit-build",
+            "Bug Tracker": "https://github.com/scikit-build/cmake-python-distributions/issues",
+        },
 
 
-    description='CMake is an open-source, cross-platform family of '
-                'tools designed to build, test and package software',
+        description='CMake is an open-source, cross-platform family of '
+                    'tools designed to build, test and package software',
 
-    long_description=readme + '\n\n' + history,
-    long_description_content_type='text/x-rst',
+        long_description=readme + '\n\n' + history,
+        long_description_content_type='text/x-rst',
 
-    classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: C',
-        'Programming Language :: C++',
-        'Programming Language :: Fortran',
-        'Programming Language :: Python',
-        'Operating System :: OS Independent',
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Build Tools',
-        'Typing :: Typed',
+        classifiers=[
+            'License :: OSI Approved :: Apache Software License',
+            'License :: OSI Approved :: BSD License',
+            'Programming Language :: C',
+            'Programming Language :: C++',
+            'Programming Language :: Fortran',
+            'Programming Language :: Python',
+            'Operating System :: OS Independent',
+            'Development Status :: 5 - Production/Stable',
+            'Intended Audience :: Developers',
+            'Topic :: Software Development :: Build Tools',
+            'Typing :: Typed',
         ],
 
-    license='Apache 2.0',
+        license='Apache 2.0',
 
-    keywords='CMake build c++ fortran cross-platform cross-compilation',
+        keywords='CMake build c++ fortran cross-platform cross-compilation',
 
-    extras_require={"test": test_requirements},
-)
+        extras_require={"test": test_requirements},
+    )
+except BaseException:
+    # Note: This is a bare exception that re-raises so that we don't interfere
+    # with anything the installation machinery might want to do. Because we
+    # print this for any exception this msg can appear (e.g. in verbose logs)
+    # even if there's no failure. For example, SetupRequirementsError is raised
+    # during PEP517 building and prints this text. setuptools raises SystemExit
+    # when compilation fails right now, but it's possible this isn't stable
+    # or a public API commitment so we'll remain ultra conservative.
+    import platform
+    import subprocess
+    try:
+        import pkg_resources
+    except ImportError:
+        pass
+
+    print(
+        """
+    =============================DEBUG ASSISTANCE=============================
+    If you are seeing a compilation error please try the following steps to
+    successfully install cmake:
+    1) Upgrade to the latest pip and try again. This will fix errors for most
+       users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
+    2) If on Linux, with glibc < 2.12, you can set PIP_ONLY_BINARY=cmake in
+       order to retrieve the last manylinux1 compatible wheel.
+    3) If on Linux, with glibc < 2.12, you can cap "cmake<3.23" in your
+       requirements in order to retrieve the last manylinux1 compatible wheel.
+    4) Open an issue with the debug information that follows at
+       https://github.com/scikit-build/cmake-python-distributions/issues
+    """
+    )
+    print("    Python: %s" % '.'.join(str(v) for v in sys.version_info[:3]))
+    print("    platform: %s" % platform.platform())
+    if sys.platform.startswith("linux"):
+        try:
+            print("    glibc: %s" % os.confstr("CS_GNU_LIBC_VERSION"))
+        except BaseException:
+            try:
+                import ctypes
+                process_namespace = ctypes.CDLL(None)
+                gnu_get_libc_version = process_namespace.gnu_get_libc_version
+                gnu_get_libc_version.restype = ctypes.c_char_p
+                glibc_version = gnu_get_libc_version()
+                if not isinstance(glibc_version, str):
+                    glibc_version = glibc_version.decode("ascii")
+                    print("    glibc: %s" % glibc_version)
+            except BaseException:
+                pass
+    if sys.platform.startswith("darwin"):
+        try:
+            macos_ver = subprocess.check_output(
+                [
+                    sys.executable,
+                    "-sS",
+                    "-c",
+                    "import platform; print(platform.mac_ver()[0])",
+                ],
+                universal_newlines=True,
+                env={"SYSTEM_VERSION_COMPAT": "0"},
+            ).strip()
+            print("    macos: %s" % macos_ver)
+        except BaseException:
+            try:
+                print("    macos: %s" % platform.mac_ver()[0])
+            except BaseException:
+                pass
+    print("    machine: %s" % platform.machine())
+    print("    bits: %d" % (64 if sys.maxsize > 2**32 else 32))
+    for dist in ["pip", "setuptools", "scikit-build"]:
+        try:
+            version = pkg_resources.get_distribution(dist).version
+        except BaseException:
+            version = "n/a"
+        print("    {}: {}".format(dist, version))
+    for key in ["PEP517_BUILD_BACKEND"]:
+        if key in os.environ:
+            print("    {}={}".format(key, os.environ[key]))
+    print(
+        """\
+    =============================DEBUG ASSISTANCE=============================
+    """
+    )
+    raise

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -9,7 +9,7 @@ DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../dist'))
 
 
 def _check_cmake_install(virtualenv, tmpdir):
-    expected_version = "3.22.6"
+    expected_version = "3.23.3"
 
     for executable_name in ["cmake", "cpack", "ctest"]:
         output = virtualenv.run(


### PR DESCRIPTION
- Update to cmake 3.23.3
- Drop manylinux1 wheels
cmake >= 3.23 requires a version of libuv that can't be built on manylinux1.
This drops manylinux1 wheels in favor of manylinux2010 wheels.