### PR TITLE
fix: only include `py.typed` package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ try:  # noqa: C901
 
         package_dir={'': 'src'},
         packages=['cmake'],
+        package_data={"cmake": ["py.typed"]},
 
         cmake_install_dir='src/cmake/data',
-        include_package_data=True,
 
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
with `include_package_data=True` setuptools include a bunch of files that shouldn't be present in the wheel.

fix #277 