### PR TITLE
Revert "Update to OpenSSL 3.0.6 (#294)"

### DIFF
--- a/scripts/manylinux-build-and-install-openssl.sh
+++ b/scripts/manylinux-build-and-install-openssl.sh
@@ -10,8 +10,8 @@ set -o pipefail
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/utils.sh
 
-OPENSSL_ROOT=openssl-3.0.6
-OPENSSL_HASH=e4a10a2986945e3f1a1f2ebd68ac780449a1773b96b6a174fdf650d6bc9611f1
+OPENSSL_ROOT=openssl-3.0.5
+OPENSSL_HASH=aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
 
 cd /tmp
 


### PR DESCRIPTION
This reverts commit 303723902e209f3ac15f01bd5e1adeb7ffed368f.

Per https://www.openssl.org:
> 12-Oct-2022 OpenSSL 3.0.6 and 1.1.1r are withdrawn. New releases will be created in due course.


