### PR TITLE
fix: Application bundle integrity issues on macOS 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,21 +380,40 @@ include\(\"${CMakeProject_BINARY_DIR}/cmake_install.cmake\")
 
     set(CMAKE_INSTALL_MESSAGE "NEVER")
 
+    if(APPLE)
+      set(distribution_root "${CMakeProject_BINARY_DISTRIBUTION_DIR}/CMake.app/Contents")
+    else()
+      set(distribution_root "${CMakeProject_BINARY_DISTRIBUTION_DIR}")
+    endif()
+
     # Install all files from binary distribution
     file(GLOB_RECURSE binary_distribution_files
       LIST_DIRECTORIES FALSE
-      ${CMakeProject_BINARY_DISTRIBUTION_DIR}/*
+      ${distribution_root}/*
       )
     foreach(file IN LISTS binary_distribution_files)
-      get_filename_component(directory ${file} DIRECTORY)
-      file(RELATIVE_PATH relative_directory ${CMakeProject_BINARY_DISTRIBUTION_DIR} ${directory})
-      set(type FILES)
-      if(relative_directory STREQUAL "bin")
-        set(type PROGRAMS)
-      endif()
       # Skip symlinks like "CMake.app/Contents/Frameworks/QtWidgets.framework/Versions/Current"
       if(IS_SYMLINK ${file})
         continue()
+      endif()
+
+      # skip some mac app bundle files
+      set(find_index -1)
+      foreach(name IN ITEMS CodeResources Info.plist Frameworks _CodeSignature MacOS PlugIns Resources doc/cmake/html man)
+        string(FIND "${file}" "${distribution_root}/${name}" find_index)
+        if("${find_index}" EQUAL 0)
+          break()
+        endif()
+      endforeach()
+      if("${find_index}" EQUAL 0)
+        continue()
+      endif()
+
+      get_filename_component(directory ${file} DIRECTORY)
+      file(RELATIVE_PATH relative_directory ${distribution_root} ${directory})
+      set(type FILES)
+      if(relative_directory STREQUAL "bin")
+        set(type PROGRAMS)
       endif()
       set(_permissions)
       get_filename_component(filename ${file} NAME)

--- a/src/cmake/__init__.py
+++ b/src/cmake/__init__.py
@@ -30,9 +30,6 @@ if not os.path.exists(CMAKE_DATA):
     if os.path.exists(_cmake_data):
         CMAKE_DATA = _cmake_data
 
-if sys.platform.startswith("darwin"):
-    CMAKE_DATA = os.path.join(CMAKE_DATA, 'CMake.app', 'Contents')
-
 CMAKE_BIN_DIR = os.path.join(CMAKE_DATA, 'bin')
 CMAKE_DOC_DIR = os.path.join(CMAKE_DATA, 'doc')
 CMAKE_SHARE_DIR = os.path.join(CMAKE_DATA, 'share')


### PR DESCRIPTION
This commit unbundles the macOS app to keep only what's really needed & get rid of the GUI stuff.

fix #301 