### PR TITLE
Revert "ci: fix issue with git security fix (#302)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "scikit-build>=0.12; python_version>='3.6'",
-    "scikit-build>=0.12,<0.16; python_version<'3.6'",
+    "scikit-build>=0.12",
     "setuptools>=42",
 ]
 build-backend = "setuptools.build_meta"
@@ -17,10 +16,7 @@ before-all = [
 before-build = "pip install -r requirements-repair.txt"
 repair-wheel-command = "python scripts/repair_wheel.py -w {dest_dir} {wheel}"
 test-extras = "test"
-test-command = [
-    "git config --global protocol.file.allow always",
-    "pytest --ignore={project}/tests/test_distribution.py {project}/tests",
-]
+test-command = "pytest --ignore={project}/tests/test_distribution.py {project}/tests"
 build-verbosity = "1"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
This reverts commit 7e5ba4b9f6591f58bf59706efda15e284e4194e3.

scikit-build 0.16 has been yanked so the check should not be required anymore.
The `git config --global protocol.file.allow always` does not work in #300  and might be dangerous if doing local builds with cibuildwheels. The CMake test suite will be fixed in 3.24.3 / 3.25.0.