### PR TITLE
chore: remove unused `requirements-deploy.txt`

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,6 +1,0 @@
-
-# need to pin cryptography for s390x/ppc64le builds:
-# cryptography never provided wheels for those architectures and the
-# requirements to build from sources are relaxed when building the 3.3 series
-cryptography~=3.3.2 ; sys_platform=="linux" and platform_machine in "s390x, ppc64le"
-twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 -r requirements-test.txt
 -r requirements-repair.txt
--r requirements-deploy.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-codecov>=2.0.5
 coverage>=4.2
 flake8>=3.0.4
 path.py>=11.5.0


### PR DESCRIPTION
This will get rid of the security alerts.