### PR TITLE
chore: use trusted publisher deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,13 +218,15 @@ jobs:
     needs: [check_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.repository == 'scikit-build/cmake-python-distributions' && startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cmake
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
-      - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_RELEASE_PASSWORD }}
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Also setting up on PyPI.
