### PR TITLE
chore: continue testing with python 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,9 +176,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        if: matrix.python != '2.7'
         name: Install Python ${{ matrix.python }}
         with:
           python-version: ${{ matrix.python }}
+
+      - name: Install Ubuntu Python 2.7
+        if: matrix.python == '2.7'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python2 python3-virtualenv
+          virtualenv -p python2 ${HOME}/cp27
+          ${HOME}/cp27/bin/python -m pip install -U pip
+          ${HOME}/cp27/bin/python -m pip install -U setuptools wheel
+          echo "${HOME}/cp27/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
`actions/setup-python` removed python 2.7 in all versions of the action.
Use Ubuntu provided python 2.7 to continue testing.

PS: I don't mind dropping python2.7 to build cmake wheel but, IMHO, as long as the wheel is built with python 2 compatibility we should at least test the wheel with python 2.7