### PR TITLE
Update to CMake 3.29.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CMakePythonDistributions_SUPERBUILD)
 
   option(RUN_CMAKE_TEST "Run CMake test suite when built from sources" ON)
 
-  set(RUN_CMAKE_TEST_EXCLUDE "BootstrapTest|RunCMake\.RuntimePath" CACHE STRING "CMake test suite exclusion regex")
+  set(RUN_CMAKE_TEST_EXCLUDE "BootstrapTest" CACHE STRING "CMake test suite exclusion regex")
 
   set(CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}"
     CACHE PATH "Directory where to download archives"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CMakePythonDistributions_SUPERBUILD)
 
   option(RUN_CMAKE_TEST "Run CMake test suite when built from sources" ON)
 
-  set(RUN_CMAKE_TEST_EXCLUDE "BootstrapTest" CACHE STRING "CMake test suite exclusion regex")
+  set(RUN_CMAKE_TEST_EXCLUDE "BootstrapTest|RunCMake\.RuntimePath" CACHE STRING "CMake test suite exclusion regex")
 
   set(CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}"
     CACHE PATH "Directory where to download archives"

--- a/CMakeUrls.cmake
+++ b/CMakeUrls.cmake
@@ -1,11 +1,11 @@
 
 #-----------------------------------------------------------------------------
 # CMake sources
-set(unix_source_url          "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3.tar.gz")
-set(unix_source_sha256       "72b7570e5c8593de6ac4ab433b73eab18c5fb328880460c86ce32608141ad5c1")
+set(unix_source_url          "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0.tar.gz")
+set(unix_source_sha256       "a0669630aae7baa4a8228048bf30b622f9e9fd8ee8cedb941754e9e38686c778")
 
-set(windows_source_url       "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3.zip")
-set(windows_source_sha256    "b54943b9c98ac66061e9b97fd630b3f06a75a85143a561ef2dca88aa0e042c60")
+set(windows_source_url       "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0.zip")
+set(windows_source_sha256    "6add9cf8a50785092d0e3d7e9e49c9812f76653b94d1b49384d6079700d42e4e")
 
 #-----------------------------------------------------------------------------
 # CMake binaries
@@ -13,17 +13,17 @@ set(windows_source_sha256    "b54943b9c98ac66061e9b97fd630b3f06a75a85143a561ef2d
 set(linux32_binary_url       "NA")  # Linux 32-bit binaries not available
 set(linux32_binary_sha256    "NA")
 
-set(linux64_binary_url       "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz")
-set(linux64_binary_sha256    "804d231460ab3c8b556a42d2660af4ac7a0e21c98a7f8ee3318a74b4a9a187a6")
+set(linux64_binary_url       "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-linux-x86_64.tar.gz")
+set(linux64_binary_sha256    "f06258f52c5649752dfb10c4c2e1d8167c760c8826f078c6f5c332fa9d976bf8")
 
-set(macos10_10_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-macos10.10-universal.tar.gz")
-set(macos10_10_binary_sha256 "5541339751cb96d1b03eb3244df7e750cd4e1dcb361ebbd68a179493dfccc5bf")
+set(macos10_10_binary_url    "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-macos10.10-universal.tar.gz")
+set(macos10_10_binary_sha256 "868f356c56a3c35e8f39f0d4fb7e579cb2eb0ac06c26520d6a203d91bdc7ad09")
 
-set(win32_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-i386.zip")
-set(win32_binary_sha256      "411812b6b29ac793faf69bdbd36c612f72659363c5491b9f0a478915db3fc58c")
+set(win32_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-windows-i386.zip")
+set(win32_binary_sha256      "db687afa0b1d0e0c5a2641b31fab050b5e2c044189b6f022ea5a09adba6cf4f5")
 
-set(win64_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-x86_64.zip")
-set(win64_binary_sha256      "cac7916f7e1e73a25de857704c94fd5b72ba9fe2f055356b5602d2f960e50e5b")
+set(win64_binary_url         "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-windows-x86_64.zip")
+set(win64_binary_sha256      "9ab28eba1ab7911a0e57ab274f5990a283fffa1d22eb711792d5562e5869f9ef")
 
-set(winarm64_binary_url      "https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-arm64.zip")
-set(winarm64_binary_sha256   "cfe023b7e82812ef802fb1ec619f6cfa2fdcb58ee61165fc315086286fe9cdcc")
+set(winarm64_binary_url      "https://github.com/Kitware/CMake/releases/download/v3.29.0/cmake-3.29.0-windows-arm64.zip")
+set(winarm64_binary_sha256   "e5bea5c45b61f105429fc664364c5280acd40770cc74235b79e7422f608a9849")

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as ITK and VTK.
 
-The CMake python wheels provide `CMake 3.28.3 <https://cmake.org/cmake/help/v3.28/index.html>`_.
+The CMake python wheels provide `CMake 3.29.0 <https://cmake.org/cmake/help/v3.29/index.html>`_.
 
 Latest Release
 --------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The suite of CMake tools were created by Kitware in response to the need
 for a powerful, cross-platform build environment for open-source projects
 such as `ITK <https://itk.org>`_ and `VTK <https://vtk.org>`_.
 
-The CMake python wheels provide `CMake 3.28.3 <https://cmake.org/cmake/help/v3.28/index.html>`_.
+The CMake python wheels provide `CMake 3.29.0 <https://cmake.org/cmake/help/v3.29/index.html>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/update_cmake_version.rst
+++ b/docs/update_cmake_version.rst
@@ -29,13 +29,13 @@ Classic procedure:
 2. Execute `scripts/update_cmake_version.py` command line tool with the desired
    ``X.Y.Z`` CMake version available for download. For example::
 
-    $ release=3.28.3
+    $ release=3.29.0
     $ ./scripts/update_cmake_version.py $release
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.28.3'
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.29.0'
     [...]
-    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.28.3' - done
-    Updating 'CMakeUrls.cmake' with CMake version 3.28.3
-    Updating 'CMakeUrls.cmake' with CMake version 3.28.3 - done
+    Collecting URLs and SHA256s from 'https://api.github.com/repos/Kitware/CMake/releases/tags/v3.29.0' - done
+    Updating 'CMakeUrls.cmake' with CMake version 3.29.0
+    Updating 'CMakeUrls.cmake' with CMake version 3.29.0 - done
     Updating docs/index.rst
     Updating docs/index.rst - done
     Updating README.rst
@@ -46,7 +46,7 @@ Classic procedure:
 3. Create a topic named `update-to-cmake-X.Y.Z` and commit the changes.
    For example::
 
-    release=3.28.3
+    release=3.29.0
     git switch -c update-to-cmake-$release
     git add -u CMakeUrls.cmake docs/index.rst README.rst tests/test_cmake.py docs/update_cmake_version.rst
     git commit -m "Update to CMake $release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ select = ["*-musllinux_x86_64", "*-musllinux_i686"]
 # disable some tests
 # - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
 # - ExportImport|RunCMake.install|RunCMake.file-GET_RUNTIME_DEPENDENCIES: c.f. https://discourse.cmake.org/t/cmake-test-suite-failing-on-alpine-linux/5064
-environment = { CMAKE_ARGS = "-DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl -DCMAKE_JOB_POOL_COMPILE:STRING=compile -DCMAKE_JOB_POOL_LINK:STRING=link -DCMAKE_JOB_POOLS:STRING=compile=4;link=1 -DRUN_CMAKE_TEST_EXCLUDE:STRING='BootstrapTest|ExportImport|RunCMake.install|RunCMake.file-GET_RUNTIME_DEPENDENCIES'" }
+environment = { CMAKE_ARGS = "-DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl -DCMAKE_JOB_POOL_COMPILE:STRING=compile -DCMAKE_JOB_POOL_LINK:STRING=link -DCMAKE_JOB_POOLS:STRING=compile=4;link=1 -DRUN_CMAKE_TEST_EXCLUDE:STRING='BootstrapTest|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES'" }
 
 [[tool.cibuildwheel.overrides]]
 select = ["*-musllinux_aarch64", "*-musllinux_ppc64le", "*-musllinux_s390x"]

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -71,7 +71,7 @@ def _get_scripts():
 
 @all_tools
 def test_cmake_script(tool):
-    expected_version = "3.28.3"
+    expected_version = "3.29.0"
     scripts = [script for script in _get_scripts() if script.stem == tool]
     assert len(scripts) == 1
     output = subprocess.check_output([str(scripts[0]), "--version"]).decode("ascii")


### PR DESCRIPTION
Created by running `nox -s bump -- --commit`

I've also pushed a final py2 release with scikit-build classic of 3.28.4 with Python 2 support fixed (it's been broken for quite a while, at least accessing it from Python has).