### PR TITLE
Init: fix importlib version compat

### DIFF
--- a/src/cmake/__init__.py
+++ b/src/cmake/__init__.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 8):
     from importlib_metadata import distribution
 else:
     from importlib.metadata import distribution


### PR DESCRIPTION
This fixes the import lib import that had the API change for Python 3.8, not Python 3.10

Fixes #472 
Fixes #471 