### PR TITLE
fix: Ensure importlib_metadata runtime dependency installed with Python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Typing :: Typed"
 ]
 dependencies = [
-  "importlib_metadata>=2.0; python_version<'3.10'",
+  "importlib_metadata>=1.4; python_version<'3.8'",
 ]
 dynamic = ["version"]
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed"
 ]
+dependencies = [
+  "importlib_metadata>=2.0; python_version<'3.10'",
+]
 dynamic = ["version"]
 requires-python = ">=3.7"
 
@@ -37,7 +40,6 @@ Source = "https://github.com/scikit-build/cmake-python-distributions"
 [project.optional-dependencies]
 test = [
   "coverage>=4.2",
-  "importlib_metadata>=2.0; python_version<'3.10'",
   "pytest>=3.0.3",
   "pytest-cov>=2.4.0",
 ]

--- a/src/cmake/__init__.py
+++ b/src/cmake/__init__.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 8):
     from importlib_metadata import distribution
 else:
     from importlib.metadata import distribution

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -7,7 +7,7 @@ import textwrap
 
 import pytest
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 8):
     from importlib_metadata import distribution
 else:
     from importlib.metadata import distribution


### PR DESCRIPTION
Fixes a regression introduced in 5f068d5 ("chore(build): move to scikitbuild-core (#455)", 2024-03-01)