### PR TITLE
chore: modernize update scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
   hooks:
   - id: ruff
     args: [--fix, --show-fixes]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: "v1.9.0"
+  hooks:
+  - id: mypy
+    files: ^(src|scripts)
+    exclude: ^src/cmake/__init__.py$
+    additional_dependencies: [types-requests]
+    args: []

--- a/noxfile.py
+++ b/noxfile.py
@@ -106,16 +106,15 @@ def _bump(session: nox.Session, name: str, repository: str, branch: str, script:
     args = parser.parse_args(session.posargs)
 
     if args.version is None:
-        session.install("lastversion")
+        session.install("lastversion", "requests")
         lastversion_args = []
         if branch:
             lastversion_args.extend(("--branch", branch))
         lastversion_args.append(repository)
         version = session.run("lastversion", *lastversion_args, log=False, silent=True).strip()
     else:
+        session.install("requests")
         version = args.version
-
-    session.install("requests")
 
     extra = ["--quiet"] if args.commit else []
     session.run("python", script, version, *extra)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,13 @@ inherit.config-settings = "append"
 config-settings."cmake.define.RUN_CMAKE_TEST" = "OFF"
 
 
+[tool.mypy]
+files = ["src", "scripts"]
+python_version = "3.8"
+strict = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+warn_unreachable = true
+
 [tool.ruff]
 src = ["src"]
 

--- a/scripts/update_openssl_version.py
+++ b/scripts/update_openssl_version.py
@@ -1,72 +1,74 @@
 #!/usr/bin/env python3
+#
+# /// script
+# dependencies = ["requests"]
+# ///
+
 """
 Command line executable allowing to update OpenSSL version.
 """
 
+from __future__ import annotations
+
 import argparse
 import contextlib
-import os
 import re
 import textwrap
+from pathlib import Path
 
-try:
-    import requests
-except ImportError:
-    raise SystemExit(
-        "requests not available: "
-        "consider installing it running 'pip install requests'"
-    ) from None
+import requests
 
-ROOT_DIR = os.path.join(os.path.dirname(__file__), "..")
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+ROOT_DIR = Path(__file__).parent.parent.resolve()
 
 
 @contextlib.contextmanager
-def _log(txt, verbose=True):
+def _log(txt: str, verbose: bool=True) -> Generator[None, None, None]:
     if verbose:
         print(txt)
     yield
     if verbose:
-        print("%s - done" % txt)
+        print(txt, "-", "done")
 
 
-def get_openssl_sha256(version, verbose=False):
+def get_openssl_sha256(version: str, verbose: bool=False) -> str:
     files_base_url = (
-        "https://www.openssl.org/source/openssl-%s.tar.gz.sha256" % version
+        f"https://www.openssl.org/source/openssl-{version}.tar.gz.sha256"
     )
-    with _log("Collecting SHA256 from '%s'" % files_base_url):
+    with _log(f"Collecting SHA256 from '{files_base_url}'"):
         sha256 = requests.get(files_base_url).content.decode("ascii").strip()
         if verbose:
-            print(f"got sha256: {sha256}")
+            print("got sha256:", sha256)
         return sha256
 
 
-def _update_file(filepath, regex, replacement):
-    msg = "Updating %s" % os.path.relpath(filepath, ROOT_DIR)
-    with _log(msg):
+def _update_file(filepath: Path, regex: re.Pattern[str], replacement: str) -> None:
+    with _log(f"Updating {filepath.relative_to(ROOT_DIR)}"):
         pattern = re.compile(regex)
-        with open(filepath) as doc_file:
-            lines = doc_file.readlines()
-            updated_content = []
-            for line in lines:
-                updated_content.append(re.sub(pattern, replacement, line))
-        with open(filepath, "w") as doc_file:
+        with filepath.open() as doc_file:
+            updated_content = [pattern.sub(replacement, line) for line in doc_file]
+        with filepath.open("w") as doc_file:
             doc_file.writelines(updated_content)
 
 
-def update_openssl_script(version, sha256):
+def update_openssl_script(version: str, sha256: str) -> None:
     pattern = re.compile(r"^OPENSSL_ROOT=.*")
-    replacement = "OPENSSL_ROOT=openssl-%s" % version
+    replacement = f"OPENSSL_ROOT=openssl-{version}"
     _update_file(
-        os.path.join(ROOT_DIR, "scripts/manylinux-build-and-install-openssl.sh"), pattern, replacement
+        ROOT_DIR / "scripts/manylinux-build-and-install-openssl.sh", pattern, replacement
     )
     pattern = re.compile(r"^OPENSSL_HASH=.*")
-    replacement = "OPENSSL_HASH=%s" % sha256
+    replacement = f"OPENSSL_HASH={sha256}"
     _update_file(
-        os.path.join(ROOT_DIR, "scripts/manylinux-build-and-install-openssl.sh"), pattern, replacement
+        ROOT_DIR / "scripts/manylinux-build-and-install-openssl.sh", pattern, replacement
     )
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "openssl_version",


### PR DESCRIPTION
This fixes the instruction printout to include `pyproject.toml` - and modernizes the whole script.
