### PR TITLE
Add back the dependency on importlib_metadata for python < 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed"
 ]
+dependencies = [
+  "importlib_metadata>=1.4; python_version<'3.8'",
+]
 requires-python = ">=3.7"
 
 [project.urls]


### PR DESCRIPTION
Fixes #489 

It looks like the dependency on `importlib_metadata` was accidentally removed in https://github.com/scikit-build/cmake-python-distributions/pull/470.

This PR adds it back.