### PR TITLE
bump version to 3.29.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "cmake"
-version = "3.29.5"
+version = "3.29.5.1"
 description = "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
 keywords = ["CMake", "build", "c++", "fortran", "cross-platform", "cross-compilation"]
 readme = "README.rst"


### PR DESCRIPTION
with setuptools_scm gone, I forgot to bump the version before tagging. Bump the version to 3.29.5.1, the tag will be overriden once this gets merged.