### PR TITLE
doc(README): Use up-to-date download stats badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Latest Release
   +----------------------------------------------------------------------+---------------------------------------------------------------------------+
   | Versions                                                             | Downloads                                                                 |
   +======================================================================+===========================================================================+
-  | .. image:: https://img.shields.io/pypi/v/cmake.svg                   | .. image:: https://img.shields.io/badge/downloads-3997k%20total-green.svg |
+  | .. image:: https://img.shields.io/pypi/v/cmake.svg                   | .. image:: https://static.pepy.tech/badge/cmake                           |
   |     :target: https://pypi.python.org/pypi/cmake                      |     :target: https://pypi.python.org/pypi/cmake                           |
   +----------------------------------------------------------------------+---------------------------------------------------------------------------+
 


### PR DESCRIPTION
Follow-up of 56fc87990 (README: Update download stats [ci skip]) switching to using "pepy.tech" badge instead of hard-coded total download count expected to be manually retrieved using Google's BigQuery.

See https://pypistats.org/faqs#what-is-the-source-of-the-download-data