### PR TITLE
feat: add manylinux_2_31 armv7l wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         if: matrix.use_qemu && fromJSON(env.USE_QEMU)
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@main
+        uses: pypa/cibuildwheel@v2.22
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,10 @@ jobs:
             use_qemu: true
           - os: ubuntu-latest
             arch: "armv7l"
+            build: "manylinux_"
+            use_qemu: true
+          - os: ubuntu-latest
+            arch: "armv7l"
             build: "musllinux_"
             use_qemu: true
           - os: windows-2019
@@ -118,7 +122,7 @@ jobs:
         if: matrix.use_qemu && fromJSON(env.USE_QEMU)
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@main
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"

--- a/README.rst
+++ b/README.rst
@@ -46,31 +46,32 @@ The following platforms are supported with binary wheels:
 
 .. table::
 
-  +---------------+--------------------------+
-  | OS            | Arch                     |
-  +===============+==========================+
-  | Windows       | | 64-bit                 |
-  |               | | 32-bit                 |
-  +---------------+--------------------------+
-  | Linux Intel   | | manylinux2010+ 64-bit  |
-  |               | | musllinux_1_1+ 64-bit  |
-  |               | | manylinux2010+ 32-bit  |
-  |               | | musllinux_1_1+ 32-bit  |
-  +---------------+--------------------------+
-  | Linux ARM     | | manylinux2014+ AArch64 |
-  |               | | musllinux_1_1+ AArch64 |
-  |               | | musllinux_1_2+ armv7l  |
-  +---------------+--------------------------+
-  | Linux PowerPC | | manylinux2014+ ppc64le |
-  |               | | musllinux_1_1+ ppc64le |
-  +---------------+--------------------------+
-  | Linux IBM Z   | | manylinux2014+ s390x   |
-  |               | | musllinux_1_1+ s390x   |
-  +---------------+--------------------------+
-  | macOS 10.10+  | Intel                    |
-  +---------------+--------------------------+
-  | macOS 11+     | Apple Silicon            |
-  +---------------+--------------------------+
+  +---------------+---------------------------+
+  | OS            | Arch                      |
+  +===============+===========================+
+  | Windows       | | 64-bit                  |
+  |               | | 32-bit                  |
+  +---------------+---------------------------+
+  | Linux Intel   | | manylinux2010+  x86_64  |
+  |               | | musllinux_1_1+  x86_64  |
+  |               | | manylinux2010+  i686    |
+  |               | | musllinux_1_1+  i686    |
+  +---------------+---------------------------+
+  | Linux ARM     | | manylinux2014+  AArch64 |
+  |               | | musllinux_1_1+  AArch64 |
+  |               | | manylinux_2_31+ armv7l  |
+  |               | | musllinux_1_2+  armv7l  |
+  +---------------+---------------------------+
+  | Linux PowerPC | | manylinux2014+  ppc64le |
+  |               | | musllinux_1_1+  ppc64le |
+  +---------------+---------------------------+
+  | Linux IBM Z   | | manylinux2014+  s390x   |
+  |               | | musllinux_1_1+  s390x   |
+  +---------------+---------------------------+
+  | macOS 10.10+  | Intel                     |
+  +---------------+---------------------------+
+  | macOS 11+     | Apple Silicon             |
+  +---------------+---------------------------+
 
 The last version to provide ``manylinux1`` wheels was ``3.22.x``.
 The last version to provide Python 2 to Python 3.6 support was ``3.28.x``.

--- a/scripts/manylinux-build-and-install-openssl.sh
+++ b/scripts/manylinux-build-and-install-openssl.sh
@@ -33,7 +33,7 @@ if ! perl -e 'use 5.10.0' &> /dev/null; then
 	popd
 	export PATH=/tmp/perl-openssl/bin:${PATH}
 else
-	if [ "${AUDITWHEEL_PLAT:0:9}" == "manylinux" ]; then
+	if [ "${AUDITWHEEL_PLAT:0:9}" == "manylinux" ] && command -v yum >/dev/null 2>&1; then
 		# more perl modules are needed than the bare minimum already installed in CentOS
 		# c.f. https://github.com/openssl/openssl/blob/openssl-3.0.0/NOTES-PERL.md#general-notes
 		yum -y install perl-core


### PR DESCRIPTION
mitigates #494

PS: armv7l (both musllinux & manylinux) are building ninja from sources for now. ref https://github.com/scikit-build/ninja-python-distributions/issues/271