### PR TITLE
fix: do not require Ninja

### DIFF
--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -1,0 +1,44 @@
+import os
+
+from scikit_build_core import build as _orig
+
+if hasattr(_orig, "prepare_metadata_for_build_editable"):
+    prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+if hasattr(_orig, "prepare_metadata_for_build_wheel"):
+    prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_editable = _orig.build_editable
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+get_requires_for_build_editable = _orig.get_requires_for_build_editable
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+
+def strtobool(value: str) -> bool:
+    """
+    Converts a environment variable string into a boolean value.
+    """
+    if not value:
+        return False
+    value = value.lower()
+    if value.isdigit():
+        return bool(int(value))
+    return value not in {"n", "no", "off", "false", "f"}
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    packages_orig = _orig.get_requires_for_build_wheel(config_settings)
+    allow_cmake = strtobool(os.environ.get("CMAKE_PYTHON_DIST_ALLOW_CMAKE_DEP", ""))
+    allow_ninja = any(
+        strtobool(os.environ.get(var, ""))
+        for var in ("CMAKE_PYTHON_DIST_FORCE_NINJA_DEP", "CMAKE_PYTHON_DIST_ALLOW_NINJA_DEP")
+    )
+    packages = []
+    for package in packages_orig:
+        package_name = package.lower().split(">")[0].strip()
+        if package_name == "cmake" and not allow_cmake:
+            msg = f"CMake PyPI distibution requires {package} to be available on the build system"
+            raise ValueError(msg)
+        if package_name == "ninja" and not allow_ninja:
+            continue
+        packages.append(package)
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-requires = ["scikit-build-core"]
-build-backend = "scikit_build_core.build"
+requires = ["scikit-build-core>=0.10"]
+build-backend = "backend"
+backend-path = ["_build_backend"]
 
 [project]
 name = "cmake"
@@ -51,10 +52,10 @@ cpack = "cmake:cpack"
 ctest = "cmake:ctest"
 
 [tool.scikit-build]
-minimum-version = "0.8"
+minimum-version = "build-system.requires"
 build-dir = "build/{wheel_tag}"
-cmake.version = ""  # We are cmake, so don't request cmake
-ninja.make-fallback = false
+cmake.version = ">=3.13"  # Since 3.24.0, CMake requires CMake 3.13+ to build itself
+ninja.make-fallback = true
 wheel.py-api = "py3"
 wheel.expand-macos-universal-tags = true
 wheel.install-dir = "cmake/data"
@@ -65,6 +66,10 @@ template = '''
 version = "${version}"
 '''
 
+[[tool.scikit-build.overrides]]
+if.env.CMAKE_PYTHON_DIST_FORCE_NINJA_DEP = true
+ninja.make-fallback = false
+
 
 [tool.cibuildwheel]
 build = "cp39-*"
@@ -72,6 +77,7 @@ test-extras = "test"
 test-command = "pytest {project}/tests"
 build-verbosity = 1
 build-frontend = "build[uv]"
+environment = { CMAKE_PYTHON_DIST_FORCE_NINJA_DEP = "1" }
 musllinux-x86_64-image = "musllinux_1_1"
 musllinux-i686-image = "musllinux_1_1"
 musllinux-aarch64-image = "musllinux_1_1"
@@ -79,8 +85,10 @@ musllinux-ppc64le-image = "musllinux_1_1"
 musllinux-s390x-image = "musllinux_1_1"
 musllinux-armv7l-image = "musllinux_1_2"
 
-[tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.10"
+[[tool.cibuildwheel.overrides]]
+select = "*-macos*"
+inherit.environment = "append"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.10" }
 
 [tool.cibuildwheel.linux]
 before-all = "./scripts/manylinux-build-and-install-openssl.sh"


### PR DESCRIPTION
This should prevent bootstrapping issues between CMake PyPI distribution and Ninja PyPI distribution when building either one from sources.

This is one of the items in https://github.com/scikit-build/cmake-python-distributions/issues/503#issuecomment-2191858783
