### PR TITLE
fix: bootstrap build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
 
     steps:
       - uses: actions/checkout@v4
@@ -266,6 +266,7 @@ jobs:
         env:
           CMAKE_ARGS: "-DBUILD_CMAKE_FROM_SOURCE:BOOL=OFF"
           CMAKE_BUILD_PARALLEL_LEVEL: "4"
+          MACOSX_DEPLOYMENT_TARGET: "10.10"
         run: |
           python -m pip install -v --no-binary='cmake,ninja' dist/*.tar.gz
           rm -rf dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,9 +219,51 @@ jobs:
       - name: Test installed SDist
         run: .venv/bin/pytest ./tests
 
+  bootstrap_build:
+    name: Bootstrap build
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        id: python
+        with:
+          python-version: "3.x"
+
+      - name: Remove cmake and ninja
+        run: |
+          # Remove cmake and ninja
+          set -euxo pipefail
+          # https://github.com/scikit-build/scikit-build-core/blob/3943920fa267dc83f9295279bea1c774c0916f13/src/scikit_build_core/program_search.py#L51
+          # https://github.com/scikit-build/scikit-build-core/blob/3943920fa267dc83f9295279bea1c774c0916f13/src/scikit_build_core/program_search.py#L70
+          for TOOL in cmake cmake3 ninja-build ninja samu; do
+            while which ${TOOL}; do
+              sudo rm -f $(which -a ${TOOL})
+            done
+          done
+
+      - name: Build SDist
+        run: pipx run --python '${{ steps.python.outputs.python-path }}' build --sdist
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libssl-dev
+
+      - name: Install SDist
+        env:
+          CMAKE_ARGS: "-DBUILD_CMAKE_FROM_SOURCE:BOOL=OFF"
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
+        run: |
+          python -m pip install -v --no-binary='cmake,ninja' dist/*.tar.gz
+          rm -rf dist
+
+      - name: Test installed SDist
+        run: python -m pip install pytest pytest-cov && pytest ./tests
+
   check_dist:
     name: Check dist
-    needs: [build_wheels, build_manylinux2010_wheels, build_sdist, test_sdist]
+    needs: [build_wheels, build_manylinux2010_wheels, build_sdist, test_sdist, bootstrap_build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,9 +220,14 @@ jobs:
         run: .venv/bin/pytest ./tests
 
   bootstrap_build:
-    name: Bootstrap build
+    name: Source only build on ${{ matrix.os }}
     needs: [lint]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest"]
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -231,6 +236,7 @@ jobs:
           python-version: "3.x"
 
       - name: Remove cmake and ninja
+        shell: bash
         run: |
           # Remove cmake and ninja
           set -euxo pipefail
@@ -238,7 +244,11 @@ jobs:
           # https://github.com/scikit-build/scikit-build-core/blob/3943920fa267dc83f9295279bea1c774c0916f13/src/scikit_build_core/program_search.py#L70
           for TOOL in cmake cmake3 ninja-build ninja samu; do
             while which ${TOOL}; do
-              sudo rm -f $(which -a ${TOOL})
+              if [ "$RUNNER_OS" == "Windows" ]; then
+                rm -f "$(which ${TOOL})"
+              else
+                sudo rm -f $(which -a ${TOOL})
+              fi
             done
           done
 
@@ -246,11 +256,13 @@ jobs:
         run: pipx run --python '${{ steps.python.outputs.python-path }}' build --sdist
 
       - name: Install dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libssl-dev
 
       - name: Install SDist
+        shell: bash
         env:
           CMAKE_ARGS: "-DBUILD_CMAKE_FROM_SOURCE:BOOL=OFF"
           CMAKE_BUILD_PARALLEL_LEVEL: "4"
@@ -259,6 +271,7 @@ jobs:
           rm -rf dist
 
       - name: Test installed SDist
+        shell: bash
         run: python -m pip install pytest pytest-cov && pytest ./tests
 
   check_dist:

--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from scikit_build_core import build as _orig
@@ -7,13 +9,12 @@ if hasattr(_orig, "prepare_metadata_for_build_editable"):
 if hasattr(_orig, "prepare_metadata_for_build_wheel"):
     prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
 build_editable = _orig.build_editable
-build_wheel = _orig.build_wheel
 build_sdist = _orig.build_sdist
 get_requires_for_build_editable = _orig.get_requires_for_build_editable
 get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
 
 
-def strtobool(value: str) -> bool:
+def _strtobool(value: str) -> bool:
     """
     Converts a environment variable string into a boolean value.
     """
@@ -25,20 +26,110 @@ def strtobool(value: str) -> bool:
     return value not in {"n", "no", "off", "false", "f"}
 
 
-def get_requires_for_build_wheel(config_settings=None):
+def get_requires_for_build_wheel(
+    config_settings: dict[str, str | list[str]] | None = None,
+) -> list[str]:
     packages_orig = _orig.get_requires_for_build_wheel(config_settings)
-    allow_cmake = strtobool(os.environ.get("CMAKE_PYTHON_DIST_ALLOW_CMAKE_DEP", ""))
+    allow_cmake = _strtobool(os.environ.get("CMAKE_PYTHON_DIST_ALLOW_CMAKE_DEP", ""))
     allow_ninja = any(
-        strtobool(os.environ.get(var, ""))
+        _strtobool(os.environ.get(var, ""))
         for var in ("CMAKE_PYTHON_DIST_FORCE_NINJA_DEP", "CMAKE_PYTHON_DIST_ALLOW_NINJA_DEP")
     )
     packages = []
     for package in packages_orig:
         package_name = package.lower().split(">")[0].strip()
         if package_name == "cmake" and not allow_cmake:
-            msg = f"CMake PyPI distibution requires {package} to be available on the build system"
-            raise ValueError(msg)
+            continue
         if package_name == "ninja" and not allow_ninja:
             continue
         packages.append(package)
     return packages
+
+
+def _bootstrap_build(temp_path: str, config_settings: dict[str, list[str] | str] | None = None) -> str:
+    import hashlib
+    import re
+    import shutil
+    import subprocess
+    import tarfile
+    import urllib.request
+    from pathlib import Path
+
+    env = os.environ.copy()
+    temp_path_ = Path(temp_path)
+
+    if "MAKE" not in env:
+        make_path = None
+        make_candidates = ("gmake", "make", "smake")
+        for candidate in make_candidates:
+            make_path = shutil.which(candidate)
+            if make_path is not None:
+                break
+        if make_path is None:
+            msg = f"Could not find a make program. Tried {make_candidates!r}"
+            raise ValueError(msg)
+        env["MAKE"] = make_path
+    make_path = env["MAKE"]
+
+    archive_path = temp_path_
+    if config_settings:
+        archive_path = Path(config_settings.get("cmake.define.CMakePythonDistributions_ARCHIVE_DOWNLOAD_DIR", archive_path))
+        archive_path.mkdir(parents=True, exist_ok=True)
+
+    cmake_urls = Path("CMakeUrls.cmake").read_text()
+    source_url = re.findall(r'set\(unix_source_url\s+"(?P<data>.*)"\)$', cmake_urls, flags=re.MULTILINE)[0]
+    source_sha256 = re.findall(r'set\(unix_source_sha256\s+"(?P<data>.*)"\)$', cmake_urls, flags=re.MULTILINE)[0]
+
+    tarball_name = source_url.rsplit("/", maxsplit=1)[1]
+    assert tarball_name.endswith(".tar.gz")
+    source_tarball = archive_path / tarball_name
+    if not source_tarball.exists():
+        with urllib.request.urlopen(source_url) as response:
+            source_tarball.write_bytes(response.read())
+
+    sha256 = hashlib.sha256(source_tarball.read_bytes()).hexdigest()
+    if source_sha256.lower() != sha256.lower():
+        msg = f"Invalid sha256 for {source_url!r}. Expected {source_sha256!r}, got {sha256!r}"
+        raise ValueError(msg)
+
+    tar_filter_kwargs = {"filter": "tar"} if hasattr(tarfile, "tar_filter") else {}
+    with tarfile.open(source_tarball) as tar:
+        tar.extractall(path=temp_path_, **tar_filter_kwargs)
+
+    parallel_str = env.get("CMAKE_BUILD_PARALLEL_LEVEL", "1")
+    parallel = max(0, int(parallel_str) if parallel_str.isdigit() else 1) or os.cpu_count() or 1
+
+    bootstrap_path = next(temp_path_.glob("cmake-*/bootstrap"))
+    prefix_path = temp_path_ / "cmake-install"
+    bootstrap_args = [f"--prefix={prefix_path}", "--no-qt-gui", "--no-debugger", "--parallel={parallel}", "--", "-DBUILD_TESTING=OFF", "-DBUILD_CursesDialog:BOOL=OFF"]
+    previous_cwd = Path().absolute()
+    os.chdir(bootstrap_path.parent)
+    try:
+        subprocess.run([bootstrap_path, *bootstrap_args], env=env, check=True)
+        subprocess.run([make_path, "-j", f"{parallel}"], env=env, check=True)
+        subprocess.run([make_path, "install"], env=env, check=True)
+    finally:
+        os.chdir(previous_cwd)
+
+    return str(prefix_path / "bin" / "cmake")
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict[str, list[str] | str] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    from scikit_build_core.errors import CMakeNotFoundError
+
+    try:
+        return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+    except CMakeNotFoundError:
+        if os.name != "posix":
+            raise
+    # Let's try bootstrapping CMake
+    import tempfile
+    with tempfile.TemporaryDirectory() as temp_path:
+        cmake_path = _bootstrap_build(temp_path, config_settings)
+        assert cmake_path
+        os.environ["CMAKE_EXECUTABLE"] = cmake_path
+        return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -1,0 +1,44 @@
+import os
+
+from scikit_build_core import build as _orig
+
+if hasattr(_orig, "prepare_metadata_for_build_editable"):
+    prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+if hasattr(_orig, "prepare_metadata_for_build_wheel"):
+    prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_editable = _orig.build_editable
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+get_requires_for_build_editable = _orig.get_requires_for_build_editable
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+
+def strtobool(value: str) -> bool:
+    """
+    Converts a environment variable string into a boolean value.
+    """
+    if not value:
+        return False
+    value = value.lower()
+    if value.isdigit():
+        return bool(int(value))
+    return value not in {"n", "no", "off", "false", "f"}
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    packages_orig = _orig.get_requires_for_build_wheel(config_settings)
+    allow_cmake = strtobool(os.environ.get("CMAKE_PYTHON_DIST_ALLOW_CMAKE_DEP", ""))
+    allow_ninja = any(
+        strtobool(os.environ.get(var, ""))
+        for var in ("CMAKE_PYTHON_DIST_FORCE_NINJA_DEP", "CMAKE_PYTHON_DIST_ALLOW_NINJA_DEP")
+    )
+    packages = []
+    for package in packages_orig:
+        package_name = package.lower().split(">")[0].strip()
+        if package_name == "cmake" and not allow_cmake:
+            msg = f"CMake PyPI distibution requires {package} to be available on the build system"
+            raise ValueError(msg)
+        if package_name == "ninja" and not allow_ninja:
+            continue
+        packages.append(package)
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ version = "${version}"
 if.env.CMAKE_PYTHON_DIST_FORCE_NINJA_DEP = true
 ninja.make-fallback = false
 
+[[tool.scikit-build.overrides]]
+if.state = "metadata_wheel"
+wheel.cmake = false
+wheel.platlib = true
+
 
 [tool.cibuildwheel]
 build = "cp39-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ ctest = "cmake:ctest"
 [tool.scikit-build]
 minimum-version = "build-system.requires"
 build-dir = "build/{wheel_tag}"
-cmake.version = ">=3.13"  # Since 3.24.0, CMake requires CMake 3.13+ to build itself
+cmake.version = "CMakeLists.txt"
 ninja.make-fallback = true
 wheel.py-api = "py3"
 wheel.expand-macos-universal-tags = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
-requires = ["scikit-build-core"]
-build-backend = "scikit_build_core.build"
+requires = ["scikit-build-core>=0.10"]
+build-backend = "backend"
+backend-path = ["_build_backend"]
 
 [project]
 name = "cmake"
@@ -51,10 +52,10 @@ cpack = "cmake:cpack"
 ctest = "cmake:ctest"
 
 [tool.scikit-build]
-minimum-version = "0.8"
+minimum-version = "build-system.requires"
 build-dir = "build/{wheel_tag}"
-cmake.version = ""  # We are cmake, so don't request cmake
-ninja.make-fallback = false
+cmake.version = ">=3.13"  # Since 3.24.0, CMake requires CMake 3.13+ to build itself
+ninja.make-fallback = true
 wheel.py-api = "py3"
 wheel.expand-macos-universal-tags = true
 wheel.install-dir = "cmake/data"
@@ -65,6 +66,10 @@ template = '''
 version = "${version}"
 '''
 
+[[tool.scikit-build.overrides]]
+if.env.CMAKE_PYTHON_DIST_FORCE_NINJA_DEP = true
+ninja.make-fallback = false
+
 
 [tool.cibuildwheel]
 build = "cp39-*"
@@ -72,6 +77,7 @@ test-extras = "test"
 test-command = "pytest {project}/tests"
 build-verbosity = 1
 build-frontend = "build[uv]"
+environment = { CMAKE_PYTHON_DIST_FORCE_NINJA_DEP = "1" }
 musllinux-x86_64-image = "musllinux_1_1"
 musllinux-i686-image = "musllinux_1_1"
 musllinux-aarch64-image = "musllinux_1_1"
@@ -79,8 +85,10 @@ musllinux-ppc64le-image = "musllinux_1_1"
 musllinux-s390x-image = "musllinux_1_1"
 musllinux-armv7l-image = "musllinux_1_2"
 
-[tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.10"
+[[tool.cibuildwheel.overrides]]
+select = "*-macos*"
+inherit.environment = "append"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.10" }
 
 [tool.cibuildwheel.linux]
 before-all = "./scripts/manylinux-build-and-install-openssl.sh"


### PR DESCRIPTION
This PR declares a custom build backend for the CMake PyPI distrbution. The following are included:
- removes the Ninja PyPI distribution build dependency by default in order to break a build cycle (cmake -> ninja -> cmake) when binary wheels are not available and Ninja is not present/too old on the build system. (this is #566)
- removes the CMake PyPI distrbution build dependency by default in order to break a build cycle (cmake -> cmake) when binary wheels are not available and CMake is not present/too old on the build system.
- Uses a bootstrapped CMake in order to build itself when CMake is not present/too old on the build system.

Relates to https://github.com/scikit-build/cmake-python-distributions/issues/503#issuecomment-2191858783.

The bootstrap build might not be efficient as we're building CMake twice but that's the easiest way I could think of and hopefully, those kind of builds should not happen that often.

close #566

