### PR TITLE
chore: align minimum cmake version with the one of scikit-build-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.15)
 
 #
 # For more details, see docs/building.rst


### PR DESCRIPTION
Since 3.24.0, CMake requires CMake 3.13+ to build itself, scikit-build-core requires 3.15+
Align the version in CMakeLists.txt with the one of scikit-build-core.
This also gets rid of a warning.