### PR TITLE
ci(linux): use GHA ARM runners to build ARM wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       use_qemu:
-        description: 'Use qemu to build linux aarch64, ppc64le & s390x'
+        description: 'Use qemu to build linux ppc64le & s390x'
         required: true
         default: true
   schedule:
@@ -60,14 +60,14 @@ jobs:
             arch: "i686"
             build: "musllinux_"
             use_qemu: false
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "aarch64"
             build: "manylinux_"
-            use_qemu: true
-          - os: ubuntu-latest
+            use_qemu: false
+          - os: ubuntu-24.04-arm
             arch: "aarch64"
             build: "musllinux_"
-            use_qemu: true
+            use_qemu: false
           - os: ubuntu-latest
             arch: "ppc64le"
             build: "manylinux_"
@@ -84,14 +84,14 @@ jobs:
             arch: "s390x"
             build: "musllinux_"
             use_qemu: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "armv7l"
             build: "manylinux_"
-            use_qemu: true
-          - os: ubuntu-latest
+            use_qemu: false
+          - os: ubuntu-24.04-arm
             arch: "armv7l"
             build: "musllinux_"
-            use_qemu: true
+            use_qemu: false
           - os: windows-2019
             arch: "AMD64"
             build: ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ config-settings."cmake.define.RUN_CMAKE_TEST" = "ON"
 config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*linux_aarch64", "*linux_armv7l", "*linux_ppc64le", "*linux_s390x"]
+select = ["*linux_ppc64le", "*linux_s390x"]
 config-settings."cmake.define.OPENSSL_ROOT_DIR" = "/usr/local/ssl"
 config-settings."cmake.define.CMAKE_JOB_POOL_COMPILE" = "compile"
 config-settings."cmake.define.CMAKE_JOB_POOL_LINK" = "link"


### PR DESCRIPTION
This will speed-up the build & allow proper testing of Linux ARM wheels.