### PR TITLE
break: drop Python 3.7, manylinux2010 & musllinux_1_1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
-          CIBW_BUILD: "cp39-${{ matrix.build }}*"
+          CIBW_BUILD: "cp310-${{ matrix.build }}*"
 
       - uses: actions/upload-artifact@v4
         if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,36 +145,6 @@ jobs:
           name: cibw-${{ runner.os }}-${{ matrix.build }}${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
-  build_manylinux2010_wheels:
-    name: Build ${{ matrix.arch }} manylinux2010 wheels
-    needs: [lint]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: "x86_64"
-          - arch: "i686"
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # required for versioneer to find tags
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1
-        env:
-          CIBW_ARCHS: "${{ matrix.arch }}"
-          CIBW_BUILD: "cp39-manylinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177"
-          CIBW_MANYLINUX_I686_IMAGE: "quay.io/pypa/manylinux2010_i686:2022-08-05-4535177"
-          CIBW_BUILD_FRONTEND: "build"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-manylinux2010-${{ matrix.arch }}
-          path: ./wheelhouse/*.whl
-
   build_sdist:
     name: Build source distribution
     needs: [lint]
@@ -290,7 +260,7 @@ jobs:
 
   check_dist:
     name: Check dist
-    needs: [build_wheels, build_manylinux2010_wheels, build_sdist, test_sdist, bootstrap_build]
+    needs: [build_wheels, build_sdist, test_sdist, bootstrap_build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/README.rst
+++ b/README.rst
@@ -52,21 +52,21 @@ The following platforms are supported with binary wheels:
   | Windows       | | 64-bit                  |
   |               | | 32-bit                  |
   +---------------+---------------------------+
-  | Linux Intel   | | manylinux2010+  x86_64  |
-  |               | | musllinux_1_1+  x86_64  |
-  |               | | manylinux2010+  i686    |
-  |               | | musllinux_1_1+  i686    |
+  | Linux Intel   | | manylinux2014+  x86_64  |
+  |               | | musllinux_1_2+  x86_64  |
+  |               | | manylinux2014+  i686    |
+  |               | | musllinux_1_2+  i686    |
   +---------------+---------------------------+
   | Linux ARM     | | manylinux2014+  AArch64 |
-  |               | | musllinux_1_1+  AArch64 |
+  |               | | musllinux_1_2+  AArch64 |
   |               | | manylinux_2_31+ armv7l  |
   |               | | musllinux_1_2+  armv7l  |
   +---------------+---------------------------+
   | Linux PowerPC | | manylinux2014+  ppc64le |
-  |               | | musllinux_1_1+  ppc64le |
+  |               | | musllinux_1_2+  ppc64le |
   +---------------+---------------------------+
   | Linux IBM Z   | | manylinux2014+  s390x   |
-  |               | | musllinux_1_1+  s390x   |
+  |               | | musllinux_1_2+  s390x   |
   +---------------+---------------------------+
   | Linux RISC-V  | | manylinux_2_35+ riscv64 |
   |               | | musllinux_1_2+  riscv64 |
@@ -77,6 +77,7 @@ The following platforms are supported with binary wheels:
   +---------------+---------------------------+
 
 The last version to provide ``manylinux1`` wheels was ``3.22.x``.
+The last version to provide Python 3.7 support and ``manylinux2010`` wheels was ``4.0.3``.
 The last version to provide Python 2 to Python 3.6 support was ``3.28.x``.
 
 Maintainers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ testpaths = ["tests"]
 
 [tool.cibuildwheel]
 archs = ["auto64", "auto32"]
-build = "cp39-*"
+build = "cp310-*"
 test-groups = ["test"]
 test-command = "pytest {project}/tests"
 build-verbosity = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Typing :: Typed"
 ]
-dependencies = [
-  "importlib_metadata>=1.4; python_version<'3.8'",
-]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://cmake.org"
@@ -109,11 +106,11 @@ manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
 manylinux-armv7l-image = "manylinux_2_31"
 manylinux-riscv64-image = "ghcr.io/mayeut/manylinux_2_35:2025.08.02-2"
-musllinux-x86_64-image = "quay.io/pypa/musllinux_1_1_x86_64:2024.10.26-1"
-musllinux-i686-image = "quay.io/pypa/musllinux_1_1_i686:2024.10.26-1"
-musllinux-aarch64-image = "quay.io/pypa/musllinux_1_1_aarch64:2024.10.26-1"
-musllinux-ppc64le-image = "quay.io/pypa/musllinux_1_1_ppc64le:2024.10.26-1"
-musllinux-s390x-image = "quay.io/pypa/musllinux_1_1_s390x:2024.10.26-1"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
 musllinux-armv7l-image = "musllinux_1_2"
 musllinux-riscv64-image = "musllinux_1_2"
 
@@ -140,7 +137,7 @@ inherit.config-settings = "append"
 # disable some tests
 # - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
 # - ExportImport|RunCMake.install|RunCMake.file-GET_RUNTIME_DEPENDENCIES: c.f. https://discourse.cmake.org/t/cmake-test-suite-failing-on-alpine-linux/5064
-config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
+config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
 
 [[tool.cibuildwheel.overrides]]
 select = ["*-musllinux_armv7l"]
@@ -158,7 +155,7 @@ inherit.config-settings = "append"
 config-settings."cmake.define.RUN_CMAKE_TEST" = "OFF"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*-musllinux_{s390x,riscv64}"]
+select = ["*-musllinux_{ppc64le,s390x,riscv64}"]
 build-frontend = "pip"
 
 

--- a/src/cmake/__init__.py
+++ b/src/cmake/__init__.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from importlib.metadata import distribution
 from pathlib import Path
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import distribution
-else:
-    from importlib.metadata import distribution
 
 from ._version import version as __version__
 

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -3,13 +3,9 @@ import subprocess
 import sys
 import sysconfig
 import textwrap
+from importlib.metadata import distribution
 
 import pytest
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import distribution
-else:
-    from importlib.metadata import distribution
 
 import cmake
 


### PR DESCRIPTION
This removes correlation between the dependabot update & dropping python 3.7, manylinux2010 & musllinux_1_1
It should probably be considered as a whole with https://github.com/scikit-build/ninja-python-distributions/pull/310