### PR TITLE
feat: add riscv64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       use_qemu:
-        description: 'Use qemu to build linux ppc64le & s390x'
+        description: 'Use qemu to build linux ppc64le, s390x & riscv64'
         required: true
         default: true
   schedule:
@@ -82,6 +82,14 @@ jobs:
             use_qemu: true
           - os: ubuntu-latest
             arch: "s390x"
+            build: "musllinux_"
+            use_qemu: true
+          - os: ubuntu-latest
+            arch: "riscv64"
+            build: "manylinux_"
+            use_qemu: true
+          - os: ubuntu-latest
+            arch: "riscv64"
             build: "musllinux_"
             use_qemu: true
           - os: ubuntu-24.04-arm

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ The following platforms are supported with binary wheels:
   | Linux IBM Z   | | manylinux2014+  s390x   |
   |               | | musllinux_1_1+  s390x   |
   +---------------+---------------------------+
+  | Linux RISC-V  | | manylinux_2_39+ riscv64 |
+  |               | | musllinux_1_2+  riscv64 |
+  +---------------+---------------------------+
   | macOS 10.10+  | Intel                     |
   +---------------+---------------------------+
   | macOS 11+     | Apple Silicon             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,12 +108,14 @@ manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
 manylinux-armv7l-image = "manylinux_2_31"
+manylinux-riscv64-image = "manylinux_2_39"
 musllinux-x86_64-image = "quay.io/pypa/musllinux_1_1_x86_64:2024.10.26-1"
 musllinux-i686-image = "quay.io/pypa/musllinux_1_1_i686:2024.10.26-1"
 musllinux-aarch64-image = "quay.io/pypa/musllinux_1_1_aarch64:2024.10.26-1"
 musllinux-ppc64le-image = "quay.io/pypa/musllinux_1_1_ppc64le:2024.10.26-1"
 musllinux-s390x-image = "quay.io/pypa/musllinux_1_1_s390x:2024.10.26-1"
 musllinux-armv7l-image = "musllinux_1_2"
+musllinux-riscv64-image = "musllinux_1_2"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macos*"
@@ -150,13 +152,13 @@ inherit.config-settings = "append"
 config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*linux_ppc64le", "*linux_s390x"]
+select = ["*linux_ppc64le", "*linux_s390x", "*linux_riscv64"]
 inherit.config-settings = "append"
 # disable tests on those platforms, QEMU is taking to long for jobs to pass on GHA
 config-settings."cmake.define.RUN_CMAKE_TEST" = "OFF"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*-musllinux_s390x"]
+select = ["*-musllinux_{s390x,riscv64}"]
 build-frontend = "pip"
 
 


### PR DESCRIPTION
This PR adds riscv64 linux wheels now that they can be uploaded to PyPI
