### PR TITLE
chore: remove cibuildwheel override for musllinux_armv7l

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,15 +140,6 @@ inherit.config-settings = "append"
 config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*-musllinux_armv7l"]
-inherit.config-settings = "append"
-# disable some tests
-# - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
-# - ExportImport|RunCMake.install|RunCMake.file-GET_RUNTIME_DEPENDENCIES: c.f. https://discourse.cmake.org/t/cmake-test-suite-failing-on-alpine-linux/5064
-# - CTestTestFdSetSize fails on gcc14+ with "error: implicit declaration of function 'usleep'""
-config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
-
-[[tool.cibuildwheel.overrides]]
 select = ["*linux_ppc64le", "*linux_s390x", "*linux_riscv64"]
 inherit.config-settings = "append"
 # disable tests on those platforms, QEMU is taking to long for jobs to pass on GHA


### PR DESCRIPTION
It's the same as the global musllinux one