### PR TITLE
chore: always run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,22 +59,22 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: "aarch64"
             build: "musllinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "ppc64le"
             build: "manylinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "ppc64le"
             build: "musllinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "s390x"
             build: "manylinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "s390x"
             build: "musllinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "riscv64"
             build: "manylinux_"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             arch: "riscv64"
             build: "musllinux_"
           - os: ubuntu-24.04-arm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,9 @@ config-settings."cmake.define.CMAKE_JOB_POOLS" = "compile=4;link=1"
 select = ["*-manylinux_armv7l"]
 inherit.config-settings = "append"
 # disable some tests
+# - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
 # - RunCMake.CompilerId fails because architecture id is not detected properly for gfortran on Ubuntu 20.04 https://gitlab.kitware.com/cmake/cmake/-/issues/27129
-config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "RunCMake.CompilerId"
+config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|RunCMake.CompilerId"
 
 [[tool.cibuildwheel.overrides]]
 select = ["*-musllinux_*"]
@@ -150,10 +151,21 @@ inherit.config-settings = "append"
 config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES"
 
 [[tool.cibuildwheel.overrides]]
-select = ["*linux_ppc64le", "*linux_s390x", "*linux_riscv64"]
+select = ["*-musllinux_ppc64le", "*-musllinux_s390x"]
 inherit.config-settings = "append"
-# disable tests on those platforms, QEMU is taking to long for jobs to pass on GHA
-config-settings."cmake.define.RUN_CMAKE_TEST" = "OFF"
+# disable some tests
+# - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
+# - ExportImport|RunCMake.install|RunCMake.file-GET_RUNTIME_DEPENDENCIES: c.f. https://discourse.cmake.org/t/cmake-test-suite-failing-on-alpine-linux/5064
+# - RunCMake.execute_process fails because QEMU prints on stderr on SIGSEGV
+config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|CTestTestFdSetSize|ExportImport|RunCMake.install|RunCMake.RuntimePath|RunCMake.file-GET_RUNTIME_DEPENDENCIES|RunCMake.execute_process"
+
+[[tool.cibuildwheel.overrides]]
+select = ["*-manylinux_ppc64le", "*-manylinux_s390x"]
+inherit.config-settings = "append"
+# disable some tests
+# - BootstrapTest fails with custom OpenSSL and probably does not make much sense for this project
+# - RunCMake.execute_process fails because QEMU prints on stderr on SIGSEGV
+config-settings."cmake.define.RUN_CMAKE_TEST_EXCLUDE" = "BootstrapTest|RunCMake.execute_process"
 
 [[tool.cibuildwheel.overrides]]
 select = ["*-musllinux_{ppc64le,s390x,riscv64}"]


### PR DESCRIPTION
All tests are now green on all platforms.
Added some exception in the test for QEMU specific behaviour.
The QEMU builds are now running on aarch64 runners which are much faster for this job than x86_64 ones (1h00 vs 1h45).

The overall build job is around 1 hour.