### PR TITLE
fix: add missing f-string prefix for --parallel bootstrap arg

### DIFF
--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -120,7 +120,7 @@ def _bootstrap_build(temp_path: str, config_settings: dict[str, list[str] | str]
         bootstrap_path = next(temp_path_.glob("cmake-*/bootstrap"))
         prefix_path = temp_path_ / "cmake-install"
         cmake_path = prefix_path / "bin" / "cmake"
-        bootstrap_args = [f"--prefix={prefix_path}", "--no-qt-gui", "--no-debugger", "--parallel={parallel}", "--", "-DBUILD_TESTING=OFF", "-DBUILD_CursesDialog:BOOL=OFF"]
+        bootstrap_args = [f"--prefix={prefix_path}", "--no-qt-gui", "--no-debugger", f"--parallel={parallel}", "--", "-DBUILD_TESTING=OFF", "-DBUILD_CursesDialog:BOOL=OFF"]
         previous_cwd = Path().absolute()
         os.chdir(bootstrap_path.parent)
         try:


### PR DESCRIPTION
The `--parallel={parallel}` argument in `_build_backend/backend.py` was a regular string instead of an f-string, causing it to literally pass `--parallel={parallel}` to the cmake bootstrap script instead of the actual parallel job count.

This resulted in single-threaded bootstrap compilation regardless of `CMAKE_BUILD_PARALLEL_LEVEL` setting.

The fix is simply adding the `f` prefix to make it `f"--parallel={parallel}"`.