### PR TITLE
fix: more readable error on missing `ccmake`

### DIFF
--- a/src/cmake/__init__.py
+++ b/src/cmake/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from importlib.metadata import distribution
@@ -50,7 +51,7 @@ def _program_exit(name: str, *args: str) -> NoReturn:
 
 
 def ccmake() -> NoReturn:
-    if not (Path(CMAKE_BIN_DIR) / "ccmake").exists():
+    if shutil.which("ccmake", path=CMAKE_BIN_DIR) is None:
         raise FileNotFoundError(
             f"'ccmake' is not available in cmake installation at '{CMAKE_BIN_DIR}'. "
             "Perhaps 'ccmake' is not yet inclucded to the package for this platform."


### PR DESCRIPTION
I've stumbled upon the error below, trying to use `ccmake`. Adding a bit more readable error for this case.

```
uv tool install cmake
# Installed 4 executables: ccmake, cmake, cpack, ctest
ccmake --version 
# Traceback (most recent call last):
#   File "<frozen runpy>", line 198, in _run_module_as_main
#   File "<frozen runpy>", line 88, in _run_code
#   File "C:\Users\Andrej\.local\bin\ccmake.exe\__main__.py", line 10, in <module>
#     sys.exit(ccmake())
#              ~~~~~~^^
#   File "L:\UV_TOOL_DIR\cmake\Lib\site-packages\cmake\__init__.py", line 53, in ccmake
#     _program_exit('ccmake', *sys.argv[1:])
#     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "L:\UV_TOOL_DIR\cmake\Lib\site-packages\cmake\__init__.py", line 47, in _program_exit
#     raise SystemExit(_program(name, args))
#                      ~~~~~~~~^^^^^^^^^^^^
#   File "L:\UV_TOOL_DIR\cmake\Lib\site-packages\cmake\__init__.py", line 43, in _program
#     return subprocess.call([os.path.join(CMAKE_BIN_DIR, name), *args], close_fds=False)
#            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "L:\UV_PYTHON_INSTALL_DIR\cpython-3.14.0-windows-x86_64-none\Lib\subprocess.py", line 395, in call
#     with Popen(*popenargs, **kwargs) as p:
#          ~~~~~^^^^^^^^^^^^^^^^^^^^^^
#   File "L:\UV_PYTHON_INSTALL_DIR\cpython-3.14.0-windows-x86_64-none\Lib\subprocess.py", line 1038, in __init__
#     self._execute_child(args, executable, preexec_fn, close_fds,
#     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#                         pass_fds, cwd, env,
#                         ^^^^^^^^^^^^^^^^^^^
#     ...<5 lines>...
#                         gid, gids, uid, umask,
#                         ^^^^^^^^^^^^^^^^^^^^^^
#                         start_new_session, process_group)
#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "L:\UV_PYTHON_INSTALL_DIR\cpython-3.14.0-windows-x86_64-none\Lib\subprocess.py", line 1552, in _execute_child
#     hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
#                        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
#                              # no special security
#                              ^^^^^^^^^^^^^^^^^^^^^
#     ...<4 lines>...
#                              cwd,
#                              ^^^^
#                              startupinfo)
#                              ^^^^^^^^^^^^
# FileNotFoundError: [WinError 2] The system cannot find the file specified
```