### PR TITLE
fix: drop manylinux1 workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,6 @@ if(CMakePythonDistributions_SUPERBUILD)
         DOWNLOAD_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_ALWAYS 1
-        ${_cmake_args}
         CMAKE_CACHE_ARGS
           -DBUILD_CursesDialog:BOOL=ON
           -DCMAKE_USE_OPENSSL:BOOL=ON


### PR DESCRIPTION
Removed initial cache file generation for CMAKE_C_FLAGS and CMAKE_EXE_LINKER_FLAGS.

See #457, should fix OpenBSD. Pretty sure it's no longer needed.